### PR TITLE
Drop the Use this template adoption path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
         # scaffold's. The pathspec matches recursively.
         run: git ls-files -z '.github/*.sh' | xargs -0 shellcheck -S style
 
-      # Validates the scaffold-shipped dev container (template repository
-      # and "Use this template" copies). Gated on the sync-header sentinel
+      # Validates the scaffold-shipped dev container (this repository's
+      # own). Gated on the sync-header sentinel
       # in post-create.sh: adopting repos without it — installer adopters,
       # or apps with their own dev container (where JSONC is legitimate) —
       # are never linted, per the ownership rule above.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ LICENSE                            MIT
 .gitattributes                     Line-ending pin: scaffold paths stay LF so the bash
                                    scripts survive Windows checkouts (core.autocrlf)
 docs/                              This repository's own development records: context
-                                   collections and ADRs about the scaffold itself (copied by
-                                   "Use this template"; the installer never ships it)
+                                   collections and ADRs about the scaffold itself
+                                   (the installer never ships it)
 .github/
   CODEOWNERS                       Human review gate on agreements/, workflows/, connectors/
   copilot-instructions.md          Repo practicalities: layout, validated commands, PR mechanics
@@ -97,8 +97,8 @@ docs/                              This repository's own development records: co
     tests/                         Offline regression tests for the CI guards (run-tests.sh)
     tuning-status.sh               Tuned or not? (report / --ci / --quiet)
 .vscode/mcp.json                   MCP servers for interactive surfaces
-.devcontainer/                     Codespaces / Dev Containers env for template contributors
-                                   (copied by "Use this template"; the installer never ships it)
+.devcontainer/                     Codespaces / Dev Containers env for kit contributors
+                                   (the installer never ships it)
 ```
 
 Everything the scaffold owns lives in `.github/` (plus root `AGENTS.md`,
@@ -182,6 +182,8 @@ bash ≥ 3.2).
      download.
    - `SCAFFOLD_REPO=owner/repo` and `SCAFFOLD_REF=<tag|branch|sha>`
      select a different source or version.
+   - Until onboarding completes, CI shows `scaffold not onboarded`
+     warnings and agents are told not to trust the command sections.
 
    **Already adopted?** Re-run with `--upgrade` to pull a newer scaffold
    (append `--dry-run` to preview first):
@@ -201,16 +203,6 @@ bash ≥ 3.2).
    ```powershell
    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/mochan-tk/agentic-dev-kit-for-copilot/main/.github/scripts/scaffold-init.ps1))) --upgrade
    ```
-
-   **Alternative for a brand-new repo:** click **Use this template** on
-   GitHub and clone.
-
-   - Copies the whole tree — including this template's `LICENSE`,
-     `.vscode/`, and `.devcontainer/`, none of which the installer ships.
-   - Replace the license with your own; keep the dev container for a
-     ready gh/jq/shellcheck environment, or delete it.
-   - Until onboarding completes, CI shows `scaffold not onboarded`
-     warnings and agents are told not to trust the command sections.
 
    *Done when:* `.github/scripts/tuning-status.sh` lists the pristine `CUSTOMIZE`
    markers and exits non-zero — the untuned state is machine-visible.

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -41,6 +41,14 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The "Use this template" adoption path is dropped; the installer is the
+  single way in and the repository stays non-template. The template path
+  copied the whole tree with no filter — this kit's own development
+  records (`docs/`, 15 files), its `LICENSE`, `.vscode/`, `.devcontainer/`
+  and the full changelog — none of which the installer ships. A brand-new
+  repository is still fully served: `git init`, then run the installer
+  (refs #1 in mochan-tk/agentic-dev-kit-for-copilot).
+
 - The top-of-README adoption banner is deleted: readers scan for Getting
   started directly, and the banner dual-maintained both the install
   commands and the onboarding journey. Install commands now appear exactly


### PR DESCRIPTION
Closes #1

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/1#issuecomment-5251089320

## What

Removes the "Use this template" adoption path. The repository stays non-template (`is_template: false`), so the README's "click **Use this template**" instruction pointed at a button that does not exist. The installer is now the single documented way in.

Why the template path was dropped rather than enabled: it copies the whole tree with no filter — this kit's own development records (`docs/`, 15 files), its `LICENSE`, `.vscode/`, `.devcontainer/`, and the full 423-line changelog — none of which the installer ships.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| "Alternative for a brand-new repo" block gone | Removed from step 1; the upgrade block now flows straight into `*Done when:*` |
| Its non-template fact survives | README L185–186: "Until onboarding completes, CI shows `scaffold not onboarded` warnings…" now a step-1 bullet |
| Repo-map notes reworded | `docs/` and `.devcontainer/` now read "(the installer never ships it)" with no template clause |
| ci.yml comment no longer claims template copies | Dev-container comment reads "(this repository's own)"; the sync-header sentinel gate is byte-identical |
| `grep -ri 'use this template' README.md .github/` empty | Command returns no output |
| CHANGELOG records the decision | SCAFFOLD-CHANGELOG.md Unreleased, top bullet, with the unfiltered-copy rationale |
| Verification wall | run-tests.sh 13 suites green; check-copilot-surface OK; check-md-links OK (41 refs); check-escalation-wording OK |

## Deviations

None. Historical mentions in `docs/**` and in released changelog entries are left alone — they record what was true at the time (declared out of scope in the issue).
