### PR TITLE
Account for all twelve labels in the README Conventions bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ to your application and is never touched by the scaffold's checks.
   (`task/<issue-number>-<short-slug>`) = 1 PR (`Closes #<n>`).
 - **Labels:** `type:epic`, `type:task`, `ai:ready`, `needs:human`,
   `needs:replan`, and exactly one of `exec:cloud | exec:app | exec:cli |
-  exec:ide` per task.
+  exec:ide` per task. Three more are situational, not per-task:
+  `risk:high` pauses a task after its plan comment until a human approves
+  (the default is pass-through), `retro:candidate` marks observed friction
+  for the retro loop, and `from:adopter` marks a feedback report — triage
+  input, not a work order.
 - **Task issue sections (parsed — do not rename):** Objective, Context &
   references, Acceptance criteria, Out of scope, File ownership,
   Verification, Routing, Handoff notes.

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -41,6 +41,14 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The README Conventions label list is complete again: it named nine of the
+  twelve labels `setup-labels.sh` creates. The three that were missing are
+  now covered in the same bullet — `risk:high` (described by its effect:
+  pauses a task after its plan comment until a human approves, where the
+  default is pass-through), `retro:candidate`, and `from:adopter`. An agent
+  reading only the README could not previously know the `risk:high` lever
+  existed (refs #3 in mochan-tk/agentic-dev-kit-for-copilot).
+
 - The "Use this template" adoption path is dropped; the installer is the
   single way in and the repository stays non-template. The template path
   copied the whole tree with no filter — this kit's own development


### PR DESCRIPTION
Closes #3

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/3#issuecomment-5251349616

## What

The README Conventions "Labels" bullet named nine labels while `setup-labels.sh` creates twelve. The omission mattered most for `risk:high`, which is not cosmetic: it pauses a task after its plan comment until a human approves, where the default is pass-through. An agent reading only the README could not know that lever existed.

The core set stays the lead statement; the three situational labels follow in the same bullet, with `risk:high` described by its effect rather than merely named.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| All twelve labels accounted for | Every name from `gh label list --json name` (12 with a `:`) appears in README.md — checked in a loop, no misses |
| Core set stays primary; situational set distinguishable | README L112–118: core list, then "Three more are situational, not per-task: …" |
| `risk:high` described by effect | "pauses a task after its plan comment until a human approves (the default is pass-through)" |
| Density unchanged — no new subsection or table | The change is confined to one bullet (3 lines → 7) |
| CHANGELOG notes the correction | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | run-tests.sh 13 suites green; check-copilot-surface OK; check-md-links OK (41 refs); check-escalation-wording OK |

## Deviations

None.
