### PR TITLE
Tell adopters to push, not just commit, in the install banner

### DIFF
--- a/.github/scripts/scaffold-init.sh
+++ b/.github/scripts/scaffold-init.sh
@@ -553,8 +553,11 @@ else
   [ -e LICENSE ] || echo " no LICENSE installed — the license choice is yours to make."
   echo
   echo " Next steps:"
-  echo "   1. Commit the scaffold:      git commit -m 'Adopt agentic-dev scaffold'"
-  echo "      (skip it and /onboard-project offers to commit and push for you)"
+  echo "   1. Commit and push:          git commit -m 'Adopt agentic-dev scaffold'"
+  echo "                                git push"
+  echo "      Actions only run from the default branch, so the scaffold has"
+  echo "      to land there before onboarding. Skip both and"
+  echo "      /onboard-project offers to commit and push for you."
   echo "   2. Onboard interactively:    open GitHub Copilot (VS Code Chat, CLI,"
   echo "      or an app session) and run /onboard-project — it interviews you,"
   echo "      bootstraps the canonical labels, offers to enable branch"

--- a/.github/scripts/tests/test-scaffold-init.sh
+++ b/.github/scripts/tests/test-scaffold-init.sh
@@ -135,6 +135,26 @@ else
   sed 's/^/    # /' "$OUT_DRYP"
 fi
 
+# --- banner: step 1 names the push, not just the commit --------------------
+# Reaching the remote default branch is a functional prerequisite: Actions
+# run workflows only from there, so a committed-but-unpushed scaffold breaks
+# onboarding mid-flight. The banner must say so, or adopters who follow it
+# literally land in exactly that state.
+OUT_PUSH="$WORK/banner-push-out.txt"
+new_target
+run_init "$TARGET" > "$OUT_PUSH" 2>&1 || true
+if grep -q 'git push' "$OUT_PUSH"; then
+  t_ok "install banner tells the adopter to push"
+else
+  t_fail "install banner tells the adopter to push"
+  sed 's/^/    # /' "$OUT_PUSH"
+fi
+if grep -q 'Actions only run from the default branch' "$OUT_PUSH"; then
+  t_ok "install banner explains why the push matters"
+else
+  t_fail "install banner explains why the push matters"
+fi
+
 # --- banner: Windows note is MSYS-shell-gated (#169) ------------------------
 # Git for Windows exports MSYSTEM; with it set the banner must point the
 # 'bash ...' next steps at Git Bash. The negative case forces MSYSTEM

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -41,6 +41,15 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The install banner now tells adopters to **push**, not just commit. Step
+  1 named only `git commit`, so an adopter who followed it literally left
+  the scaffold off the remote default branch — where Actions never run,
+  breaking label bootstrapping and onboarding mid-flight. The banner now
+  names both commands, says why the push matters, and makes clear that
+  `/onboard-project` can do both if you skip them; a regression test keeps
+  the wording from drifting back (refs #8 in
+  mochan-tk/agentic-dev-kit-for-copilot).
+
 - The README Conventions label list is complete again: it named nine of the
   twelve labels `setup-labels.sh` creates. The three that were missing are
   now covered in the same bullet — `risk:high` (described by its effect:


### PR DESCRIPTION
Closes #8

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/8#issuecomment-5251731038

## What

The install banner's step 1 said "Commit the scaffold: `git commit -m …`" and never mentioned pushing. Reaching the remote default branch is a functional prerequisite — Actions run workflows only from there — so an adopter who followed the banner literally ended up in the exact state the onboarding preflight exists to catch. The parenthetical only covered the *skip* path, which left the documented happy path as the broken one.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Step 1 names commit **and** push | Live banner: `1. Commit and push:  git commit -m 'Adopt agentic-dev scaffold'` / `git push` |
| Parenthetical covers skipping both | "Skip both and /onboard-project offers to commit and push for you." |
| Step 1 says why the push matters | "Actions only run from the default branch, so the scaffold has to land there before onboarding." |
| Upgrade banner untouched | No diff in the `--upgrade` branch of the banner block |
| Shape preserved | Still two numbered steps, same column alignment, no new section |
| Regression test | `install banner tells the adopter to push` + `install banner explains why the push matters`; proven non-vacuous by deleting the `git push` line and watching the first case report `not ok`, then restoring it |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | run-tests.sh 13 suites / 67 cases green; check-copilot-surface OK; check-md-links OK; check-escalation-wording OK; manual install into a scratch repository read back the banner above |

## Deviations

None. The installer still commits nothing itself — only the wording of the handoff changed.
