### PR TITLE
Show a push command that works from an app session

### DIFF
--- a/.github/scripts/scaffold-init.sh
+++ b/.github/scripts/scaffold-init.sh
@@ -552,12 +552,22 @@ else
   done
   [ -e LICENSE ] || echo " no LICENSE installed — the license choice is yours to make."
   echo
+  # Name the default branch in the push command so it works from the app
+  # session path: a worktree on its own generated branch, with no upstream.
+  # Resolved locally only — `origin/HEAD` exists in clones but not after a
+  # plain `git init` + `git remote add`, so fall back to a placeholder the
+  # adopter substitutes rather than guessing a name.
+  DEFAULT_BRANCH="$( { git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true; } | sed 's#^[^/]*/##' )"
+  [ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH="<default-branch>"
   echo " Next steps:"
-  echo "   1. Commit and push:          git commit -m 'Adopt agentic-dev scaffold'"
-  echo "                                git push"
+  echo "   1. Land it on the default branch:"
+  echo "        git commit -m 'Adopt agentic-dev scaffold'"
+  echo "        git push origin HEAD:$DEFAULT_BRANCH"
   echo "      Actions only run from the default branch, so the scaffold has"
-  echo "      to land there before onboarding. Skip both and"
-  echo "      /onboard-project offers to commit and push for you."
+  echo "      to reach it before onboarding — a push to any other branch"
+  echo "      does not count. If that branch is protected, push your own"
+  echo "      branch and open a PR instead. Skip all of this and"
+  echo "      /onboard-project offers to do it for you."
   echo "   2. Onboard interactively:    open GitHub Copilot (VS Code Chat, CLI,"
   echo "      or an app session) and run /onboard-project — it interviews you,"
   echo "      bootstraps the canonical labels, offers to enable branch"

--- a/.github/scripts/tests/test-scaffold-init.sh
+++ b/.github/scripts/tests/test-scaffold-init.sh
@@ -135,24 +135,30 @@ else
   sed 's/^/    # /' "$OUT_DRYP"
 fi
 
-# --- banner: step 1 names the push, not just the commit --------------------
+# --- banner: step 1 lands the scaffold on the default branch ---------------
 # Reaching the remote default branch is a functional prerequisite: Actions
 # run workflows only from there, so a committed-but-unpushed scaffold breaks
-# onboarding mid-flight. The banner must say so, or adopters who follow it
-# literally land in exactly that state.
+# onboarding mid-flight. A bare `git push` is not enough guidance either --
+# on the app-session path the adopter sits on a generated branch with no
+# upstream, where it fails outright and would miss the default branch anyway.
 OUT_PUSH="$WORK/banner-push-out.txt"
 new_target
 run_init "$TARGET" > "$OUT_PUSH" 2>&1 || true
-if grep -q 'git push' "$OUT_PUSH"; then
-  t_ok "install banner tells the adopter to push"
+if grep -q 'git push origin HEAD:' "$OUT_PUSH"; then
+  t_ok "install banner pushes to the default branch explicitly"
 else
-  t_fail "install banner tells the adopter to push"
+  t_fail "install banner pushes to the default branch explicitly"
   sed 's/^/    # /' "$OUT_PUSH"
 fi
 if grep -q 'Actions only run from the default branch' "$OUT_PUSH"; then
   t_ok "install banner explains why the push matters"
 else
   t_fail "install banner explains why the push matters"
+fi
+if grep -q 'protected' "$OUT_PUSH"; then
+  t_ok "install banner names the protected-branch alternative"
+else
+  t_fail "install banner names the protected-branch alternative"
 fi
 
 # --- banner: Windows note is MSYS-shell-gated (#169) ------------------------

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -41,6 +41,17 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The install banner now shows a push command that works on the app-session
+  path. It previously printed a bare `git push`, which assumes the adopter
+  is on the default branch with an upstream configured — neither holds in a
+  Copilot app worktree session, where the command fails outright ("no
+  upstream branch") and, even when it succeeds elsewhere, pushes to a branch
+  Actions never read. Step 1 now states the goal (land the scaffold on the
+  remote default branch), prints `git push origin HEAD:<default>` with the
+  branch name resolved locally from `origin/HEAD` (placeholder when it
+  cannot be resolved), and names the protected-branch alternative in one
+  clause (refs #10 in mochan-tk/agentic-dev-kit-for-copilot).
+
 - The install banner now tells adopters to **push**, not just commit. Step
   1 named only `git commit`, so an adopter who followed it literally left
   the scaffold off the remote default branch — where Actions never run,


### PR DESCRIPTION
Closes #10

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/10#issuecomment-5251969687

## What

The banner printed a bare `git push`, which quietly assumes the adopter is on the default branch with an upstream configured. On the Copilot app path — a worktree on its own generated branch — it fails outright:

```
fatal: The current branch mochan-tk-literate-memory has no upstream branch.
```

And even where it succeeds, pushing a non-default branch misses the branch Actions read, which is the entire point of the step.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Step 1 states the goal, not a bare push | Banner: `1. Land it on the default branch:` |
| Command works with no upstream, off the default branch | Replayed the reported failure (clone → `git checkout -b mochan-tk-literate-memory`, no upstream): banner printed `git push origin HEAD:main`; running it produced `HEAD -> main` and the upstream repository's `main` now carries the adoption commit |
| Branch name resolved, not hardcoded | `git symbolic-ref … refs/remotes/origin/HEAD` stripped to the branch name; a plain `git init` + `git remote add` leaves it unset, so the banner prints `HEAD:<default-branch>` — both cases exercised |
| Protected-branch case named in one clause | "If that branch is protected, push your own branch and open a PR instead." |
| "Why" and skip clauses survive | "Actions only run from the default branch … a push to any other branch does not count." / "Skip all of this and /onboard-project offers to do it for you." |
| Shape preserved | Two numbered steps, same alignment, no new section |
| Regression tests updated | Three cases: pushes to the default branch explicitly / explains why / names the protected-branch alternative. Proven non-vacuous by reverting the command to a bare `git push` and watching the first case report `not ok` |
| Verification wall | run-tests.sh 13 suites / 68 cases green; check-copilot-surface OK; check-md-links OK; check-escalation-wording OK; `shellcheck -S style` over `.github/*.sh` clean |

## Deviations

One beyond the issue text: the first attempt at resolving the branch name broke the banner entirely. `set -euo pipefail` is in force, so `git symbolic-ref` returning non-zero aborted the script mid-banner — caught by running a real install rather than trusting the diff. The resolution is wrapped in `{ … || true; }`, and the `git init` case is now exercised explicitly.
