### PR TITLE
Name skills first; mark slash commands as the VS Code shortcut

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -11,8 +11,8 @@ body:
     attributes:
       value: |
         Keep Epics coarse. Only the phase about to start gets decomposed into
-        Task sub-issues — via the `/breakdown-epic` prompt or
-        `.github/skills/plan-management/SKILL.md`. Rationale comments on this
+        Task sub-issues — via the `plan-management` skill (in VS Code, the
+        `/breakdown-epic` shortcut does the same). Rationale comments on this
         issue are the plan's change log.
   - type: input
     id: outcome

--- a/.github/scripts/scaffold-init.sh
+++ b/.github/scripts/scaffold-init.sh
@@ -567,12 +567,13 @@ else
   echo "      to reach it before onboarding — a push to any other branch"
   echo "      does not count. If that branch is protected, push your own"
   echo "      branch and open a PR instead. Skip all of this and"
-  echo "      /onboard-project offers to do it for you."
-  echo "   2. Onboard interactively:    open GitHub Copilot (VS Code Chat, CLI,"
-  echo "      or an app session) and run /onboard-project — it interviews you,"
-  echo "      bootstraps the canonical labels, offers to enable branch"
-  echo "      protection, verifies commands by running them, and opens the"
-  echo "      evidence PR."
+  echo "      onboarding offers to do it for you."
+  echo "   2. Onboard interactively:    open GitHub Copilot (app session, CLI,"
+  echo "      or VS Code Chat) and run the 'project-onboarding' skill — in"
+  echo "      VS Code the shortcut '/onboard-project' does the same. It"
+  echo "      interviews you, bootstraps the canonical labels, then"
+  echo "      offers to enable branch protection, verifies commands by"
+  echo "      running them, and opens the evidence PR."
   # Git for Windows / MSYS2 shells always export MSYSTEM; WSL, macOS and
   # Linux never do. Warn there: typing plain 'bash' into PowerShell may
   # resolve to the WSL launcher (different filesystem, no gh login) — the
@@ -587,7 +588,7 @@ else
   echo " non-zero — the untuned state is machine-visible."
   echo
   echo " AI agent running this install on a human's behalf: relay the two"
-  echo " next steps above to the human and offer to run /onboard-project"
-  echo " now — do not summarize this handoff away."
+  echo " next steps above to the human and offer to run the"
+  echo " 'project-onboarding' skill now — do not summarize this handoff away."
   echo "=================================================================="
 fi

--- a/.github/scripts/tests/test-scaffold-init.sh
+++ b/.github/scripts/tests/test-scaffold-init.sh
@@ -458,7 +458,8 @@ fi
 # Agent-mediated installs (#144) drop the handoff unless the banner tells
 # the installing agent to relay it — assert that instruction is printed.
 if grep -q "AI agent running this install" "$OUT145" \
-   && grep -q "offer to run /onboard-project" "$OUT145"; then
+   && grep -q "offer to run the" "$OUT145" \
+   && grep -q "'project-onboarding' skill now" "$OUT145"; then
   t_ok "handoff banner carries the agent-relay instruction"
 else
   t_fail "handoff banner carries the agent-relay instruction"
@@ -466,7 +467,7 @@ fi
 
 # --- handoff banner: two steps, labels+ruleset folded into onboarding ------
 # The manual "Bootstrap labels" (#175) and "Branch ruleset" (#187) steps
-# moved inside /onboard-project; the banner must show commit -> onboard,
+# moved inside onboarding; the banner must show commit -> onboard,
 # mention the consent-gated protection offer, and say "two next steps".
 if ! grep -q "Bootstrap labels:" "$OUT145" \
    && ! grep -q "Branch ruleset:" "$OUT145" \
@@ -554,7 +555,7 @@ if grep -q "refreshed   .github/scripts/some-guard.sh" "$OUT_UPG" \
 else
   t_fail "upgrade banner reports refreshed and kept files by class"
 fi
-if ! grep -q "offer to run /onboard-project" "$OUT_UPG" \
+if ! grep -q "'project-onboarding' skill now" "$OUT_UPG" \
    && grep -q "AI agent running this upgrade" "$OUT_UPG" \
    && grep -q "git diff --cached" "$OUT_UPG"; then
   t_ok "upgrade banner replaces onboarding handoff with diff-review handoff"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ docs/                              This repository's own development records: co
     session-orchestration/           parent/child session protocol
     verification/                    gates, evidence, CI-failure triage
     retro/                           failures -> system improvements (+ upstreaming)
-  prompts/                         Slash commands: /onboard-project /kickoff-context
+  prompts/                         VS Code Copilot Chat shortcuts to the skills above:
+                                   /onboard-project /kickoff-context
                                    /distill-context /breakdown-epic /start-task
                                    /replan /retro
   connectors/                      Context connectors: Contract + conformance rules
@@ -210,10 +211,9 @@ bash ≥ 3.2).
 
    *Done when:* `.github/scripts/tuning-status.sh` lists the pristine `CUSTOMIZE`
    markers and exits non-zero — the untuned state is machine-visible.
-2. **Onboard** — run `/onboard-project` in VS Code Copilot Chat, Copilot
-   CLI, or a Copilot app session (any surface that reads
-   `.github/prompts/`), or hand any capable agent
-   `.github/skills/project-onboarding/SKILL.md`.
+2. **Onboard** — run the `project-onboarding` skill in a Copilot app
+   session, Copilot CLI, or VS Code Copilot Chat; in VS Code the shortcut
+   `/onboard-project` does the same.
 
    - It inventories the repo, asks only the gaps, verifies commands by
      running them, and fills or removes every `CUSTOMIZE` block across
@@ -226,8 +226,9 @@ bash ≥ 3.2).
    - It ends with one evidence PR — review and merge it (the **license
      merge**). Manual fallback: search the repo for `CUSTOMIZE` and fill
      by hand.
-   - After the merge, review the drafted Epic and run `/breakdown-epic`
-     on it to turn it into Task issues (full flow: step 6).
+   - After the merge, review the drafted Epic and break it down into Task
+     issues — the `plan-management` skill (VS Code: `/breakdown-epic`);
+     full flow in step 6.
 
    *Done when:* `.github/scripts/tuning-status.sh` exits 0 on the merged main.
 3. **MCP** — interactive surfaces read `.vscode/mcp.json`; for the cloud
@@ -281,8 +282,9 @@ bash ≥ 3.2).
      agreements PR → human merges (= agreement). Skip when there is nothing
      above the promotion bar yet — most knowledge rides in Task issues.
    - Review the Epic drafted during onboarding — edit or replace it (form
-     or `templates/epic-body.md`) — then run `/breakdown-epic` → approve →
-     Task issues exist, wired and routed.
+     or `templates/epic-body.md`) — then break it down (`plan-management`;
+     VS Code: `/breakdown-epic`) → approve → Task issues exist, wired and
+     routed.
    - Dispatch the frontier: `exec:cloud` → assign the issue to Copilot;
      `exec:app` → open a parent session with the **orchestrator** agent and
      let it spawn one child session per task (`/start-task` inside each);

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -41,6 +41,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The adoption instructions now name skills first: prompt files under
+  `.github/prompts/` are a VS Code Copilot Chat feature, so `/onboard-project`
+  is not a command in a Copilot app session or in Copilot CLI — it arrives as
+  plain text and works only if the model infers a skill was meant. Skills are
+  the portable layer (an open standard loaded by VS Code, Copilot CLI, and the
+  cloud agent alike), and `.github/skills/project-onboarding/SKILL.md` already
+  carries every instruction the prompt does, so nothing is lost by pointing
+  adopters at it. The install banner, README steps 2 and 6, the repo map, and
+  the Epic template now read "run the `<name>` skill (in VS Code: `/<shortcut>`)";
+  the prompt files keep working unchanged for VS Code users (refs #12 in
+  mochan-tk/agentic-dev-kit-for-copilot).
+
 - The install banner now shows a push command that works on the app-session
   path. It previously printed a bare `git push`, which assumes the adopter
   is on the default branch with an upstream configured — neither holds in a


### PR DESCRIPTION
Closes #12

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/12#issuecomment-5252397864

## What

The adoption instructions told every adopter to run `/onboard-project`, but prompt files are a VS Code Copilot Chat feature. In a Copilot app session or Copilot CLI the string is not a command — it arrives as plain text and works only if the model infers a skill was meant. An adopter reported exactly that: the command never appeared in the app's list.

Skills are the portable layer, so the human entry points now name the skill and mark the slash form as the VS Code shortcut.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Banner names the skill, marks the shortcut | Live banner step 2: "run the 'project-onboarding' skill — in VS Code the shortcut '/onboard-project' does the same"; two-step shape and alignment unchanged |
| Agent-relay line no longer pushes a VS Code-only command | "offer to run the 'project-onboarding' skill now" |
| README step 2 leads with the skill; fallback survives | L213–215 lead; the `CUSTOMIZE`-by-hand fallback still at L226–227 |
| Both `/breakdown-epic` pointers name the skill path | Step 2 (L228–230) and step 6 (L284–287): "the `plan-management` skill (VS Code: `/breakdown-epic`)" |
| Repo map no longer claims universal slash commands | L72: "VS Code Copilot Chat shortcuts to the skills above:" |
| Epic template readable outside VS Code | "via the `plan-management` skill (in VS Code, the `/breakdown-epic` shortcut does the same)" |
| Nothing renamed, moved or deleted | `.github/prompts/**` and `.github/skills/**` untouched — diff covers README, banner, its tests, the Epic template, and the changelog only |
| CHANGELOG records it | SCAFFOLD-CHANGELOG.md Unreleased, top bullet, including why skills are the portable layer |
| Verification wall | run-tests.sh 13 suites / 68 cases green; check-copilot-surface OK; check-md-links OK; check-escalation-wording OK; `shellcheck -S style` clean; manual install read the banner back |

## Deviations

Two, both in the fixtures rather than the plan:

1. Three banner assertions in `test-scaffold-init.sh` matched the old wording (`offer to run /onboard-project`, twice as a positive and once as a negative for the upgrade banner). Updated deliberately to the new phrase, keeping each assertion's original intent — including the negative one that proves the upgrade banner does *not* carry the onboarding handoff.
2. Rewrapping step 2 briefly split `offers to enable branch` across two `echo` lines, which broke the "labels and ruleset live inside onboarding" assertion. Caught by the suite, not by reading the diff; fixed by moving the line break instead of weakening the test.
