### PR TITLE
Exempt the onboarding evidence PR from the task-ritual wall

### DIFF
--- a/.github/scripts/check-task-ritual.sh
+++ b/.github/scripts/check-task-ritual.sh
@@ -54,11 +54,19 @@
 # Usage:
 #   check-task-ritual.sh [<pr-number>]     # or set PR_NUMBER
 #
-# Exemption: only allowlisted dependency bots skip the ritual (default:
-# dependabot[bot] renovate[bot] github-actions[bot]; override with
-# RITUAL_EXEMPT_BOTS, space-separated logins). Any other bot author —
-# cloud coding agents included — holds a session and is held to the
-# full ritual.
+# Exemptions — two, both narrow:
+#   1. Allowlisted dependency bots skip the ritual (default: dependabot[bot]
+#      renovate[bot] github-actions[bot]; override with RITUAL_EXEMPT_BOTS,
+#      space-separated logins). Any other bot author — cloud coding agents
+#      included — holds a session and is held to the full ritual.
+#   2. The onboarding evidence PR, which has no upstream Task because it *is*
+#      the deliverable. It must carry the skill-mandated title
+#      `scaffold: onboard <project>`, target an adopted scaffold (the base
+#      branch's scaffold-version marker names a real commit, not the
+#      template's own `sha=unknown`), and target a base that still carries
+#      CUSTOMIZE markers. Those last two make the exemption self-limiting: it
+#      holds at most once per adopting repository and lapses the moment
+#      onboarding merges.
 #
 # Requires: GitHub CLI (gh), authenticated. Repo context comes from the
 # checkout ({owner}/{repo} placeholders); set GH_REPO to override.
@@ -109,9 +117,59 @@ fi
 
 body=$(api "repos/{owner}/{repo}/pulls/${PR}" --jq '.body // ""')
 
-# The first task link names the primary Task under review.
+# The onboarding evidence PR is the one legitimate PR with no upstream Task:
+# it *is* the deliverable, and no Task issue exists when it opens. Exempt it,
+# but only when every signal agrees, so an ordinary PR cannot claim the
+# exemption by choosing a title:
+#
+#   1. the title the onboarding skill mandates, `scaffold: onboard <project>`;
+#   2. an adopting repository, not this template itself — the base branch's
+#      scaffold-version marker names a real commit, where the template's own
+#      copy reads `sha=unknown`;
+#   3. a base branch that has not been onboarded yet — CUSTOMIZE markers still
+#      present there.
+#
+# Signals 2 and 3 make the exemption self-limiting: it holds at most once per
+# adopting repository and lapses the moment the onboarding PR merges, because
+# the base tree is tuned from then on. Signal 3 must be measured against the
+# *base*, never the PR tree — the onboarding PR is precisely the change that
+# removes those markers, so its own tree is already tuned.
+base_ref=$(api "repos/{owner}/{repo}/pulls/${PR}" --jq '.base.ref')
+title=$(api "repos/{owner}/{repo}/pulls/${PR}" --jq '.title // ""')
+if printf '%s\n' "$title" | grep -qE '^scaffold: onboard '; then
+  # Read the base tree through the API so the check behaves identically
+  # wherever it runs — the workflow's checkout may not carry the base ref.
+  base_file() {
+    api "repos/{owner}/{repo}/contents/$1?ref=${base_ref}" --jq '.content' 2>/dev/null \
+      | base64 -d 2>/dev/null || true
+  }
+  adopted=0
+  base_file 'SCAFFOLD-CHANGELOG.md' \
+    | grep -qE '^<!-- scaffold-version: repo=[^ ]+ sha=[0-9a-f]{7,40} ' && adopted=1
+  base_untuned=0
+  base_file '.github/copilot-instructions.md' | grep -q 'CUSTOMIZE' && base_untuned=1
+
+  if [[ "$adopted" -eq 1 && "$base_untuned" -eq 1 ]]; then
+    echo "PASS: PR #${PR} is the onboarding evidence PR (title '${title}'). Its base"
+    echo "      '${base_ref}' is an adopted scaffold that still carries CUSTOMIZE"
+    echo "      markers, so no Task issue exists yet — this PR is the deliverable."
+    echo "      The exemption lapses once onboarding merges."
+    exit 0
+  fi
+  echo "note: PR #${PR} is titled like an onboarding PR, but base '${base_ref}' is"
+  if [[ "$adopted" -eq 0 ]]; then
+    echo "      not an adopted scaffold (no pinned scaffold-version marker);"
+  else
+    echo "      already onboarded;"
+  fi
+  echo "      the full start ritual applies."
+fi
+
+# The first task link names the primary Task under review. A qualifier may sit
+# between the keyword and the number ("Refs Epic #2") — the phrasing is
+# accurate and rejecting it buys no safety.
 link=$(printf '%s\n' "$body" \
-  | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?)[[:space:]]+#[0-9]+' \
+  | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?)[[:space:]]+([A-Za-z]+[[:space:]]+)?#[0-9]+' \
   | head -n1 || true)
 if [[ -z "$link" ]]; then
   echo "FAIL: PR #${PR} body has no task link (e.g. 'Closes #N', or 'Refs #N' for post-merge acceptance)."

--- a/.github/scripts/tests/lib.sh
+++ b/.github/scripts/tests/lib.sh
@@ -73,11 +73,12 @@ stage_all() {
 # `gh api <path> [--paginate] --jq <expr>` from JSON fixtures in
 # $GH_FIXTURES: pull.json (PR endpoint), commits.json (PR commits),
 # comments.json (issue comments list), comment.json (single comment by
-# id), issue.json (issue metadata), repo.json (bare repository
-# endpoint), user.json (authenticated user), org.json (organization
-# endpoint). jq runs with -r to mirror gh's raw --jq output. No network,
-# no auth, no repository state. A missing fixture file exits non-zero,
-# which models a 404 to the caller.
+# id), issue.json (issue metadata), contents.json (repository contents
+# endpoint; contents-changelog.json for SCAFFOLD-CHANGELOG.md), repo.json
+# (bare repository endpoint), user.json (authenticated user), org.json
+# (organization endpoint). jq runs with -r to mirror gh's raw --jq output.
+# No network, no auth, no repository state. A missing fixture file exits
+# non-zero, which models a 404 to the caller.
 install_gh_shim() {
   mkdir -p "$1/bin"
   cat > "$1/bin/gh" <<'SHIM'
@@ -101,6 +102,8 @@ case "$path" in
   orgs/*) fixture="$GH_FIXTURES/org.json" ;;
   repos/*/pulls/*/commits) fixture="$GH_FIXTURES/commits.json" ;;
   repos/*/pulls/*) fixture="$GH_FIXTURES/pull.json" ;;
+  repos/*/contents/SCAFFOLD-CHANGELOG.md*) fixture="$GH_FIXTURES/contents-changelog.json" ;;
+  repos/*/contents/*) fixture="$GH_FIXTURES/contents.json" ;;
   repos/*/issues/comments/*) fixture="$GH_FIXTURES/comment.json" ;;
   repos/*/issues/*/comments) fixture="$GH_FIXTURES/comments.json" ;;
   repos/*/issues/*) fixture="$GH_FIXTURES/issue.json" ;;

--- a/.github/scripts/tests/test-task-ritual.sh
+++ b/.github/scripts/tests/test-task-ritual.sh
@@ -56,6 +56,47 @@ GH_FIXTURES="$CASE" expect_rc 0 "allowlisted bot PR is exempt" bash "$GUARD" 12
 new_case '{"user":{"login":"mochan-tk","type":"User"},"body":"No link here."}' '[]'
 GH_FIXTURES="$CASE" expect_rc 1 "PR body without a task link fails" bash "$GUARD" 12
 
+# --- onboarding evidence PR is exempt, but only when every signal agrees -----
+# It is the one legitimate PR with no upstream Task: it *is* the deliverable.
+# The exemption needs the mandated title, an adopted scaffold (pinned
+# scaffold-version marker), and a base that still carries CUSTOMIZE markers —
+# so it cannot be claimed by title alone, cannot be claimed inside the
+# template repository itself, and lapses once onboarding merges.
+b64() { printf '%s\n' "$1" | base64 | tr -d '\n'; }
+ADOPTED_CL='{"content":"'"$(b64 '<!-- scaffold-version: repo=o/kit sha=3023fe08aa6161ecdc25c563a774bd51962af038 date=2026-08-11 -->')"'"}'
+TEMPLATE_CL='{"content":"'"$(b64 '<!-- scaffold-version: repo=o/kit sha=unknown date=unknown -->')"'"}'
+UNTUNED_BASE='{"content":"'"$(b64 'CUSTOMIZE: fill this in')"'"}'
+TUNED_BASE='{"content":"'"$(b64 'Real project commands here.')"'"}'
+ONBOARD_PR='{"user":{"login":"mochan-tk","type":"User"},"title":"scaffold: onboard my-project","base":{"ref":"main"},"body":"## Task\\n\\nNo Task issue exists yet — this PR *is* the onboarding deliverable. Refs Epic #2"}'
+
+onboarding_case() { # <changelog-fixture> <instructions-fixture> [<pr-json>]
+  new_case "${3:-$ONBOARD_PR}" '[]'
+  printf '%s\n' "$1" > "$CASE/contents-changelog.json"
+  printf '%s\n' "$2" > "$CASE/contents.json"
+}
+
+onboarding_case "$ADOPTED_CL" "$UNTUNED_BASE"
+GH_FIXTURES="$CASE" expect_rc 0 "onboarding PR on an adopted, untuned base is exempt" bash "$GUARD" 3
+
+onboarding_case "$ADOPTED_CL" "$TUNED_BASE"
+GH_FIXTURES="$CASE" expect_rc 1 "onboarding-shaped PR on an onboarded base is not exempt" bash "$GUARD" 3
+
+# The template repository's own marker reads sha=unknown, so a PR here cannot
+# borrow the exemption however it is titled.
+onboarding_case "$TEMPLATE_CL" "$UNTUNED_BASE"
+GH_FIXTURES="$CASE" expect_rc 1 "onboarding-shaped PR in the template repository is not exempt" bash "$GUARD" 3
+
+# An ordinary PR cannot borrow it either: without the mandated title the
+# ritual applies in full.
+onboarding_case "$ADOPTED_CL" "$UNTUNED_BASE" \
+  '{"user":{"login":"mochan-tk","type":"User"},"title":"Add a feature","base":{"ref":"main"},"body":"No link here."}'
+GH_FIXTURES="$CASE" expect_rc 1 "ordinary PR gets no exemption from an untuned base" bash "$GUARD" 12
+
+# --- a qualifier between keyword and number still parses ---------------------
+# "Refs Epic #2" is accurate phrasing; rejecting it bought no safety.
+new_case '{"user":{"login":"mochan-tk","type":"User"},"title":"Land it","base":{"ref":"main"},"body":"Refs Epic #12\\n\\nPlan: https://github.com/o/r/issues/12#issuecomment-777"}' "[$CLAIM, $PLAN_HEADING]"
+GH_FIXTURES="$CASE" expect_rc 0 "task link tolerates a qualifier before the number" bash "$GUARD" 12
+
 # --- claim missing fails -----------------------------------------------------
 new_case "$HUMAN_PR_BODY" "[$PLAN_HEADING, $NOISE]"
 GH_FIXTURES="$CASE" expect_rc 1 "issue without a start claim fails" bash "$GUARD" 12

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The onboarding evidence PR no longer fails the `task-ritual` wall. The wall
+  demands every PR link a Task issue carrying a start claim and a plan
+  comment, but during onboarding no Task exists — the PR *is* the deliverable
+  — so every adopter hit a red check on their very first PR and could only
+  merge by bypassing it. The wall now exempts that PR when three signals
+  agree: the skill-mandated title `scaffold: onboard <project>`, a base
+  branch whose scaffold-version marker names a real commit (so the template
+  repository itself cannot claim it), and a base that still carries CUSTOMIZE
+  markers. The last two make the exemption self-limiting — it holds at most
+  once per adopting repository and lapses the moment onboarding merges.
+  Separately, the task-link extractor now tolerates a qualifier between
+  keyword and number, so the accurate `Refs Epic #2` parses (refs #16).
+
 - Issue references in this changelog no longer mis-resolve. GitHub resolves
   a bare `#<n>` against the repository the file lives in, so the numbers
   inherited from where this kit was developed did not go dead — they linked


### PR DESCRIPTION
Closes #16

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/16#issuecomment-5253290084

## What

The onboarding evidence PR — the first PR any adopter opens — always failed `task-ritual`, because the wall requires a linked Task issue carrying a start claim and a plan comment. During onboarding no Task exists: the PR *is* the deliverable. Adopters could only merge by bypassing the wall on day one.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Onboarding PR passes without a Task or bypass | Ran the guard against the reported PR (`GH_REPO=mrmo-sandbox/present-stackchan-for-misaki-hbd-v3`, PR #3): now `PASS … the exemption lapses once onboarding merges`, rc=0. It failed before this change |
| Exemption is narrow, and stated in the header | Three signals must agree: mandated title, base whose scaffold-version marker names a real commit, base still carrying CUSTOMIZE markers. Documented in the script header |
| A look-alike PR still fails | Fixture cases: onboarded base → fail; template repository (`sha=unknown`) → fail; ordinary title → fail |
| Ordinary task PRs unaffected | Ran the guard against this repository's own PR #15: full ritual verified (claim → plan → commit, plan link, `type:task`), rc=0 |
| Link extractor tolerates a qualifier | `Refs Epic #2` now parses; covered by a fixture. Chose this over changing the skill's wording — the phrasing is accurate and rejecting it bought no safety |
| Fixtures cover pass and fail | 5 new cases in `test-task-ritual.sh` (13 total, was 8); `lib.sh`'s gh shim gained the contents endpoint |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | run-tests.sh 14 suites green; check-copilot-surface OK; check-changelog-refs OK; check-md-links OK; check-escalation-wording OK; `shellcheck -S style` clean |

## Deviations

The design changed twice, both times because measurement contradicted the plan:

1. The issue suggested keying on "the untuned working tree". Cloning the affected repository showed the onboarding PR branch is already **tuned** — it is the change that fills the markers — while its base is not. The signal had to move to the base.
2. Base-untuned alone then exempted PRs in this repository, because the template's own `copilot-instructions.md` legitimately carries CUSTOMIZE markers. A test caught it. The scaffold-version marker distinguishes the two: `sha=unknown` in the template, a real commit in an adopted instance.
