### PR TITLE
Create the board's Roadmap, Kanban and Backlog views

### DIFF
--- a/.github/scripts/setup-project.sh
+++ b/.github/scripts/setup-project.sh
@@ -16,9 +16,9 @@
 #
 # Subcommands:
 #   init   Create (or reuse) a Projects v2 board titled "<repo> roadmap" by
-#   init   Create (or reuse) a Projects v2 board titled "<repo> roadmap" by
 #          default, add DATE fields `Start date` and `Target date` and a
-#          SINGLE_SELECT field `Kind` (options Epic, Task) if missing, link
+#          SINGLE_SELECT field `Kind` (options Epic, Task) if missing, create
+#          the `Roadmap`, `Kanban` and `Backlog` views if missing, link
 #          the project to the repository, and print the project number and
 #          URL. Re-running is a no-op. Projects v2 boards are always
 #          user/org-owned (repo-owned boards no longer exist); the repo
@@ -41,10 +41,11 @@
 #                            current directory belongs to (via `gh repo view`).
 #   -h, --help               Show this help and exit.
 #
-# One-time manual steps (not scriptable): create the Roadmap *view* in the
-# project UI, pick `Start date` / `Target date` as its date fields, and set
-# "Group by" to `Kind` to separate Epics from Tasks — view creation and
-# configuration are not exposed by the GitHub API.
+# Views are created by name (`Roadmap`, `Kanban`, `Backlog`) and matched by
+# name on re-runs, so an adopter's own views are never renamed or removed.
+# What stays manual: `createProjectV2View` takes only a name and a layout —
+# its `configuration` input carries `visibleFieldIds` alone — so the Roadmap
+# view's date fields and "Group by: Kind" must be set once in the UI.
 #
 # Requires: gh >= 2.45 (`gh project link`) authenticated with the `project`
 # scope, and jq.
@@ -216,6 +217,41 @@ reuse it and complete the fields and the repository link"
     echo "Created SINGLE_SELECT field 'Kind' (Epic, Task)."
   fi
 
+  # Working views. `createProjectV2View` takes a name and a layout; its
+  # `configuration` input carries only `visibleFieldIds`, so grouping and the
+  # roadmap's date fields cannot be set through the API and stay manual.
+  # Matched by name, so an adopter's own views are never renamed or removed.
+  local project_id existing_views view_spec view_name view_layout
+  project_id="$(gh project view "$number" --owner "$owner" --format json --jq '.id')"
+  # shellcheck disable=SC2016  # $id is a GraphQL variable, not a shell expansion
+  existing_views="$(gh api graphql -f query='
+    query($id: ID!) {
+      node(id: $id) { ... on ProjectV2 { views(first: 50) { nodes { name } } } }
+    }' -f id="$project_id" --jq '.data.node.views.nodes[].name' 2>/dev/null || true)"
+
+  for view_spec in "Roadmap:ROADMAP_LAYOUT" "Kanban:BOARD_LAYOUT" "Backlog:TABLE_LAYOUT"; do
+    view_name="${view_spec%%:*}"
+    view_layout="${view_spec##*:}"
+    if printf '%s\n' "$existing_views" | grep -Fxq "$view_name"; then
+      echo "View '$view_name' already exists; skipping."
+      continue
+    fi
+    # A board still sets up without its views: Projects permissions vary by
+    # account and organization, so a refusal here warns rather than aborts.
+    # shellcheck disable=SC2016  # $p/$n/$l are GraphQL variables, not shell expansions
+    if gh api graphql -f query='
+      mutation($p: ID!, $n: String!, $l: ProjectV2ViewLayout!) {
+        createProjectV2View(input: {projectId: $p, name: $n, layout: $l}) {
+          projectV2View { id }
+        }
+      }' -f p="$project_id" -f n="$view_name" -f l="$view_layout" >/dev/null 2>&1; then
+      echo "Created '$view_name' view ($view_layout)."
+    else
+      echo "warning: could not create the '$view_name' view; add it in the"
+      echo "         project UI (New view -> ${view_layout%%_*} layout)."
+    fi
+  done
+
   # Safe to repeat: linking an already-linked repository succeeds silently.
   gh project link "$number" --owner "$owner" --repo "$REPO"
   echo "Linked project #$number to $REPO."
@@ -227,9 +263,10 @@ reuse it and complete the fields and the repository link"
   url="$(gh project view "$number" --owner "$owner" --format json --jq '.url')"
   echo "Project number: $number"
   echo "Project URL:    $url"
-  echo "One-time manual steps: create a Roadmap view in the project UI, pick"
-  echo "'Start date' / 'Target date' as its date fields, and set 'Group by'"
-  echo "to 'Kind' to separate Epics from Tasks."
+  echo "Remaining manual step: open the Roadmap view and pick 'Start date' /"
+  echo "'Target date' as its date fields, then set 'Group by' to 'Kind' to"
+  echo "separate Epics from Tasks — the API creates views but cannot configure"
+  echo "grouping or date fields."
 }
 
 cmd_dates() {

--- a/.github/scripts/tests/test-setup-project.sh
+++ b/.github/scripts/tests/test-setup-project.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test-setup-project.sh — regression tests for .github/scripts/setup-project.sh.
+#
+# Scope here: the working views `init` ensures on the roadmap board. The
+# script talks to GitHub through `gh project …` and `gh api graphql`; the
+# shim below answers both from per-case fixtures, so no network, no auth and
+# no Projects permissions are needed.
+#
+# Why views are worth a guard: `createProjectV2View` accepts only a name and
+# a layout, and the board is created once per adopting repository, so a
+# silent regression here is invisible until an adopter opens the board.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+SCRIPT="$REPO_ROOT/.github/scripts/setup-project.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/projtest.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# A `gh` stand-in for the project surface. Existing views come from
+# $VIEWS_FIXTURE (one name per line); every createProjectV2View call appends
+# its arguments to $CREATED_LOG. CREATE_FAILS=1 makes creation refuse, which
+# models an account without Projects write access.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  project)
+    case "${2:-}" in
+      list)  printf '{"projects":[{"number":6,"title":"r roadmap","closed":false}]}\n' ;;
+      view)  printf '{"id":"PVT_test","url":"https://github.com/orgs/o/projects/6"}\n' ;;
+      field-list) printf '{"fields":[{"name":"Start date"},{"name":"Target date"},{"name":"Kind"}]}\n' ;;
+      link)  : ;;
+      *)     : ;;
+    esac
+    ;;
+  api)
+    # The only GraphQL reads/writes the script makes on the project surface.
+    args="$*"
+    case "$args" in
+      *createProjectV2View*)
+        [ "${CREATE_FAILS:-0}" = "1" ] && exit 1
+        printf '%s\n' "$args" >> "$CREATED_LOG"
+        printf '{"data":{"createProjectV2View":{"projectV2View":{"id":"PVTV_x"}}}}\n'
+        ;;
+      *views*)
+        # --jq '.data.node.views.nodes[].name' is applied by real gh; the
+        # shim emits the already-projected list the script consumes.
+        cat "$VIEWS_FIXTURE"
+        ;;
+      *) : ;;
+    esac
+    ;;
+  repo) printf 'o/r\n' ;;
+  *) : ;;
+esac
+SHIM
+chmod +x "$WORK/bin/gh"
+PATH="$WORK/bin:$PATH"
+export PATH
+
+run_init() {
+  VIEWS_FIXTURE="$1" CREATED_LOG="$2" CREATE_FAILS="${3:-0}" \
+    bash "$SCRIPT" init --owner o -R o/r 2>&1
+}
+
+# --- an empty board gains all three views ---------------------------------
+: > "$WORK/views-none.txt"
+: > "$WORK/created-none.log"
+out=$(run_init "$WORK/views-none.txt" "$WORK/created-none.log")
+missing=""
+for v in Roadmap Kanban Backlog; do
+  grep -q "$v" "$WORK/created-none.log" || missing="$missing $v"
+done
+if [ -z "$missing" ]; then
+  t_ok "init creates Roadmap, Kanban and Backlog on a bare board"
+else
+  t_fail "init creates Roadmap, Kanban and Backlog on a bare board (missing:$missing)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+
+# Each view must ask for its own layout, or the board looks right and reads wrong.
+layouts_ok=1
+grep -q 'Roadmap.*ROADMAP_LAYOUT\|ROADMAP_LAYOUT.*Roadmap' "$WORK/created-none.log" || layouts_ok=0
+grep -q 'Kanban.*BOARD_LAYOUT\|BOARD_LAYOUT.*Kanban' "$WORK/created-none.log" || layouts_ok=0
+grep -q 'Backlog.*TABLE_LAYOUT\|TABLE_LAYOUT.*Backlog' "$WORK/created-none.log" || layouts_ok=0
+if [ "$layouts_ok" = "1" ]; then
+  t_ok "each view is created with its own layout"
+else
+  t_fail "each view is created with its own layout"
+  sed 's/^/    # /' "$WORK/created-none.log"
+fi
+
+# --- re-running creates nothing -------------------------------------------
+printf 'Roadmap\nKanban\nBacklog\n' > "$WORK/views-all.txt"
+: > "$WORK/created-all.log"
+run_init "$WORK/views-all.txt" "$WORK/created-all.log" >/dev/null
+if [ ! -s "$WORK/created-all.log" ]; then
+  t_ok "re-running an already-viewed board creates nothing"
+else
+  t_fail "re-running an already-viewed board creates nothing"
+  sed 's/^/    # /' "$WORK/created-all.log"
+fi
+
+# --- a partially built board gains only what is missing -------------------
+# An adopter who made a Kanban view by hand keeps it; the other two appear.
+printf 'Kanban\n' > "$WORK/views-partial.txt"
+: > "$WORK/created-partial.log"
+run_init "$WORK/views-partial.txt" "$WORK/created-partial.log" >/dev/null
+if grep -q 'Roadmap' "$WORK/created-partial.log" \
+   && grep -q 'Backlog' "$WORK/created-partial.log" \
+   && ! grep -q '"Kanban"' "$WORK/created-partial.log"; then
+  t_ok "a partially built board gains only the missing views"
+else
+  t_fail "a partially built board gains only the missing views"
+  sed 's/^/    # /' "$WORK/created-partial.log"
+fi
+
+# --- refused creation warns but does not abort setup ----------------------
+# Projects write access varies by account; losing the views must not cost
+# the adopter the board and its fields.
+: > "$WORK/views-fail.txt"
+: > "$WORK/created-fail.log"
+out=$(run_init "$WORK/views-fail.txt" "$WORK/created-fail.log" 1)
+rc=$?
+if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -q 'warning: could not create'; then
+  t_ok "a refused view creation warns and setup still completes"
+else
+  t_fail "a refused view creation warns and setup still completes (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+
+t_summary

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- `setup-project.sh init` now creates the board's working views —
+  `Roadmap` (roadmap layout), `Kanban` (board layout), `Backlog` (table
+  layout). It previously created none and told the adopter to build them in
+  the UI, because view creation "is not exposed by the GraphQL API"; that
+  stopped being true, and `createProjectV2View` handles all three layouts.
+  Views are matched by name on re-runs, so nothing is duplicated and an
+  adopter's own views are never renamed or removed; a refused creation warns
+  and leaves the board and its fields intact, since Projects write access
+  varies by account. Still manual, and now stated as such: the Roadmap view's
+  date fields and "Group by: Kind" — `createProjectV2View`'s configuration
+  input carries `visibleFieldIds` alone (refs #18).
+
 - The onboarding evidence PR no longer fails the `task-ritual` wall. The wall
   demands every PR link a Task issue carrying a start claim and a plan
   comment, but during onboarding no Task exists — the PR *is* the deliverable


### PR DESCRIPTION
Closes #18

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/18#issuecomment-5254046557

## What

`setup-project.sh init` built the roadmap board and its fields but created no views, printing "create a Roadmap view in the project UI" instead. Every adopter had to build and name the working views by hand. The script's stated reason — view creation is not exposed by the API — is out of date.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Three named views on a fresh board | Live run against the reported board: `Created 'Roadmap' view (ROADMAP_LAYOUT)`, `Kanban (BOARD_LAYOUT)`, `Backlog (TABLE_LAYOUT)`. Read back via `gh api graphql`: `Roadmap (ROADMAP_LAYOUT)`, `Kanban (BOARD_LAYOUT)`, `Backlog (TABLE_LAYOUT)` |
| Roadmap date fields / grouping | Not expressible: `CreateProjectV2ViewInput.configuration` accepts `visibleFieldIds` only (checked via introspection). The script now prints that one remaining manual step rather than implying the whole view was manual |
| Idempotent re-run | Second live run: `View 'Roadmap' already exists; skipping.` ×3, no duplicates on the board. Fixture case asserts nothing is created when all three exist |
| Pre-existing board gains what is missing | The reported board — created before this change, with hand-made unnamed views — now carries the three named views; its 8 items and 16 fields are untouched. Fixture case covers the partial-board path (a hand-made `Kanban` is kept) |
| Stale claims removed | Header and the adopter-facing message now state what is automatic and what is not |
| Graceful degradation | Fixture case with creation refused: warns per view, exits 0, board and fields still set up |
| Tests | New `test-setup-project.sh`, 5 cases, gh-shim driven. Proven non-vacuous: dropping `Kanban` from the list turns two cases red; disabling the exists-check turns the idempotence case red |
| Verification wall | run-tests.sh 15 suites green (was 14); check-copilot-surface OK; check-changelog-refs OK; check-md-links OK; check-escalation-wording OK; `shellcheck -S style` clean |

## Deviations

1. **The issue's premise was half wrong, and I wrote it that way** — the first version said the board had "a single default view". It actually had four, three added by hand after setup. Corrected the issue before implementing; the real defect is that the script creates none.
2. Fixed a duplicated line in the script's own header (`init  Create (or reuse)…` appeared twice) while editing that block.
3. `test-setup-project.sh` is also named in #5. This PR creates the file; #5 should add its auth-preflight cases to it rather than creating it again.
