### PR TITLE
Correct the Epic's state line when a phase is decomposed

### DIFF
--- a/.github/prompts/breakdown-epic.prompt.md
+++ b/.github/prompts/breakdown-epic.prompt.md
@@ -32,5 +32,10 @@ Epic issue number: ${input:epicNumber}
    schedule spans with `setup-project.sh dates` where dates are known.
    Never block decomposition on this: a decline is simply noted, and a
    missing `project` scope is reported with `gh auth refresh -s project`.
-7. Post one summary comment on the Epic listing what was created and why,
+7. Update the Epic body's state line: replace the onboarding draft marker
+   ("Draft from onboarding — … nothing is decomposed until you approve.")
+   with one line naming the phase just decomposed and today's date. An Epic
+   that never carried the marker simply gains the line. Rewriting it each
+   round keeps it true — rolling-wave decomposes the same Epic repeatedly.
+8. Post one summary comment on the Epic listing what was created and why,
    including the board outcome (URL, declined, or blocked).

--- a/.github/skills/plan-management/SKILL.md
+++ b/.github/skills/plan-management/SKILL.md
@@ -49,6 +49,15 @@ this.
    disjoint **File ownership** path sets. If two tasks need the same paths,
    add a `blocked-by` edge between them — serialization by dependency beats
    merge-conflict roulette.
+5. Once the round's Task issues exist, correct the Epic body's state line:
+   replace the onboarding draft marker (*"Draft from onboarding — … nothing
+   is decomposed until you approve."*) with one line naming the phase just
+   decomposed and the date. Epics without that marker simply gain the line.
+   Rewrite the same line on every later round — an Epic is decomposed many
+   times, so a one-shot "approved" claim would go stale immediately. This
+   is the one issue body an executing session may edit: AGENTS.md §5 binds
+   an agent to its own **Task** issue, and the Epic is the plan it works
+   from, not the work order it executes.
 
 ## The frontier
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Decomposition now corrects the Epic's state line. Onboarding opens a draft
+  Epic with "nothing is decomposed until you approve", but nothing ever
+  removed that marker, so an Epic that had been reviewed, approved and split
+  into Task sub-issues still told every later reader — human or agent — the
+  opposite of the truth. The decomposition procedure now replaces it with one
+  line naming the phase just decomposed and the date, rewritten each round so
+  it stays true under rolling-wave; Epics that never carried the marker
+  simply gain the line. The skill states why this edit does not breach the
+  single-writer rule: AGENTS.md §5 binds an agent to its own Task issue, and
+  an Epic is the plan it works from, not the work order it executes
+  (refs #20).
+
 - `setup-project.sh init` now creates the board's working views —
   `Roadmap` (roadmap layout), `Kanban` (board layout), `Backlog` (table
   layout). It previously created none and told the adopter to build them in


### PR DESCRIPTION
Closes #20

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/20#issuecomment-5254497027

## What

Onboarding opens a draft Epic with "nothing is decomposed until you approve." Nothing ever removed it, so an Epic that had been reviewed, approved and split into seven Task sub-issues still opened with a line saying the opposite — observed on a real adoption.

The fix rewrites the line instead of deleting it. The marker states a *state*, and under rolling-wave an Epic is decomposed repeatedly, so a one-shot "approved" claim would go stale on the next round. The replacement names the phase just decomposed and the date, and is rewritten each round.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Epic no longer claims to be an unapproved draft | `plan-management/SKILL.md` step 5 and `breakdown-epic.prompt.md` step 7 both instruct the rewrite once the round's Task issues exist |
| Idempotent and safe without the marker | Wording is "replace … Epics without that marker simply gain the line", never a blind delete. Verified against the real Epic body: the marker line matches and is replaced; a body without it is unaffected |
| §5 reconciled explicitly | Skill states it inline: §5 binds an agent to its own **Task** issue; an Epic is the plan it works from, not the work order it executes |
| Partial decomposition not misrepresented | The line names the decomposed phase and says later phases stay coarse; it is rewritten every round rather than asserting the Epic is fully planned |
| Stated in the skill, prompt mirrors it | Skill carries the procedure and the rationale; the prompt carries the numbered step. `grep -c 'draft marker'` = 1 in each — no duplicated instruction that could fire twice |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (ceilings: SKILL.md 209/500); run-tests.sh 15 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

## Deviations

None. Checked whether `replan.prompt.md` needed the same step — it does not decompose, so it is untouched.
