### PR TITLE
Draft one Epic per phase during onboarding

### DIFF
--- a/.github/prompts/onboard-project.prompt.md
+++ b/.github/prompts/onboard-project.prompt.md
@@ -28,9 +28,10 @@ Optional context from me: ${input:notes}
    canonical labels (`.github/scripts/setup-labels.sh`), ask my consent
    to enable branch protection now (state the admin PR-only bypass and
    Free-plan caveats) and run `.github/scripts/setup-ruleset.sh` per my
-   answer, draft the outline Epic from my goal and material (coarse,
-   draft-marked, no decomposition, `/breakdown-epic` pointer at the end of
-   the body), and give me its URL to review while you verify.
+   answer, draft the phase Epics from my goal and material (one per phase,
+   siblings never nested, `blocked-by` in order, coarse, draft-marked, no
+   decomposition, `/breakdown-epic` pointer at the end of the first
+   phase's body), and give me their URLs to review while you verify.
 3. **P3:** verify candidate commands by actually running them; keep an
    evidence log (command, prerequisites, result, workarounds). Show me the
    log before applying anything.
@@ -44,13 +45,14 @@ Optional context from me: ${input:notes}
 5. **P5/P6:** prove (`tuning-status.sh` exits 0; gates run once) and open
    one PR titled `scaffold: onboard <project>` with the evidence log in the
    description, plus the retro-log row and any upstream candidates. Append
-   everything left undone in P0–P5 to the draft Epic body as a
+   everything left undone in P0–P5 to the first phase Epic's body as a
    `## Deferred from onboarding` checklist (to the PR description when the
-   Epic was skipped), and end the PR description with a `## Next steps`
-   section (merge this PR → review the Epic → `/breakdown-epic`). You are
+   Epics were skipped), and end the PR description with a `## Next steps`
+   section (merge this PR → review the Epics → `/breakdown-epic` on the
+   first phase). You are
    not done at push: the PR must exist (if its creation is blocked, tell me
    and print the exact `gh pr create` command), and the chat message where
    you hand me the PR link must end with the numbered handoff — 1. merge
-   the evidence PR, 2. review the draft Epic (link it), 3. run
-   `/breakdown-epic` on it when it looks right. Queued or failing checks
+   the evidence PR, 2. review the draft Epics (link them), 3. run
+   `/breakdown-epic` on the first phase when it looks right. Queued or failing checks
    don't waive the handoff: report problems above it, never instead of it.

--- a/.github/skills/plan-management/SKILL.md
+++ b/.github/skills/plan-management/SKILL.md
@@ -36,7 +36,9 @@ this.
 ## Rolling-wave decomposition
 
 1. Create Epics for the whole outline up front — cheap, low detail, gives the
-   "what comes next" visibility agents need for preparation.
+   "what comes next" visibility agents need for preparation. One Epic per
+   phase, all siblings: the graph is two levels, so an Epic is never a
+   sub-issue of another Epic. Order them with `blocked-by`.
 2. Decompose an Epic into Task sub-issues only when its phase is about to
    start (or when the frontier is nearly empty). Detail decays; write it late.
 3. Every Task must clear the planner quality bar

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -20,7 +20,7 @@ Three invariants govern everything below:
   it has been executed in a clean environment during this onboarding, with
   its output (or failure + workaround) captured for the PR.
 - **Onboarding tunes; it does not build.** The deliverables are the tuned
-  scaffold, the evidence PR, and the draft Epic — never application code or
+  scaffold, the evidence PR, and the draft Epics — never application code or
   infrastructure changes. Application goals in the adopter's material are
   Epic content; work that cannot run here (missing tools, external systems,
   credentials) becomes a *Deferred from onboarding* entry (P6), not work to
@@ -151,18 +151,24 @@ give the adopter something to review during it:
    Record the choice and the script output in the evidence log. An API
    refusal (Free-plan private repo) is recorded the same way and never
    blocks onboarding.
-3. Draft the **outline Epic** on GitHub from the stated goal and the
+3. Draft the **phase Epics** on GitHub from the stated goal and the
    handed-over material, using the Epic form fields (outcome, success
-   criteria, scope, coarse phase outline). Keep it coarse — no Task
-   decomposition, no invented REQ-### IDs; cite handed-over documents by
-   name. Open the body with a draft marker: *"Draft from onboarding —
-   review and edit freely; nothing is decomposed until you approve."* End
-   the body with the next-move pointer: *"When this Epic looks right, run
-   `/breakdown-epic` on it."* — the pointer rides in the body because the
-   closing chat handoff may never reach whoever picks the Epic up.
-4. Hand the Epic URL to the adopter with: review this while I verify.
+   criteria, scope, coarse phase outline) — one Epic per phase of the
+   outline, as siblings; an Epic is never a sub-issue of another Epic. A
+   one-phase outline yields exactly one. Wire them `blocked-by` in phase
+   order, since ordering lives in dependencies, not prose. Keep every Epic
+   coarse — no Task decomposition, no invented REQ-### IDs; cite
+   handed-over documents by name. Open each body with a draft marker:
+   *"Draft from onboarding — review and edit freely; nothing is decomposed
+   until you approve."* End the **first phase's** body with the next-move
+   pointer: *"When this Epic looks right, run `/breakdown-epic` on it."* —
+   the pointer rides in the body because the closing chat handoff may never
+   reach whoever picks the Epic up. Later phases stay coarse until their
+   turn and say so instead.
+4. Hand the adopter every Epic URL, first phase first, with: review these
+   while I verify.
 
-Skip the draft (labels and the consent question still run) only when the
+Skip the drafts (labels and the consent question still run) only when the
 adopter stated no goal and handed over nothing — then note the Epic form
 for later.
 
@@ -217,9 +223,11 @@ Then write the **Deferred from onboarding ledger**: collect every item
 left undone or unverified across P0–P5 — commands that could not run
 (missing tools), external operations (pushes, deploys, credentials,
 resource provisioning), skipped or declined consent steps — and append
-them to the draft Epic body as a `## Deferred from onboarding` section,
-one checklist line each with the blocking reason. When the Epic was
-skipped, carry the same section in the evidence PR description instead.
+them to the **first phase Epic's** body as a `## Deferred from onboarding`
+section, one checklist line each with the blocking reason — the ledger is
+about onboarding, so it rides the Epic that is ready to move, not every
+phase. When the Epics were skipped, carry the same section in the evidence
+PR description instead.
 Chat is not a carrier: a deferred item that exists only in the final
 message evaporates with the session.
 
@@ -233,15 +241,15 @@ filled in. Queued checks, CI failures, or other problems do not waive it:
 report them *above* the block, never instead of it.
 
 1. Review and merge the evidence PR (the license merge).
-2. Review and edit the P2-close draft Epic — link it here (or say it was
-   skipped and point at the Epic form).
-3. When the Epic looks right, run `/breakdown-epic` on it — decomposition
-   into Task issues starts only on your approval; each ready Task then
-   runs via `/start-task`.
+2. Review and edit the P2-close draft Epics — link them here, first phase
+   first (or say they were skipped and point at the Epic form).
+3. When the first phase's Epic looks right, run `/breakdown-epic` on it —
+   decomposition into Task issues starts only on your approval, one phase
+   at a time; each ready Task then runs via `/start-task`.
 
 The same three moves ride durable carriers: the evidence PR description
-**ends with a `## Next steps` section**, and the draft Epic body already
-carries its `/breakdown-epic` pointer (P2-close). Durable copies exist
+**ends with a `## Next steps` section**, and the first phase Epic's body
+already carries its `/breakdown-epic` pointer (P2-close). Durable copies exist
 because chat can die; the chat block exists because adopters read chat,
 not PR descriptions — neither substitutes for the other, and a PR
 announcement without the block is an unfinished P6. This checklist lives

--- a/README.md
+++ b/README.md
@@ -221,14 +221,14 @@ bash ≥ 3.2).
      `copilot-setup-steps.yml`).
    - Along the way it bootstraps the canonical label set
      (`.github/scripts/setup-labels.sh` — idempotent; `-R owner/repo`
-     targets another repo) and drafts an outline Epic from your goal and
-     material for you to review.
+     targets another repo) and drafts one outline Epic per phase from your
+     goal and material for you to review.
    - It ends with one evidence PR — review and merge it (the **license
      merge**). Manual fallback: search the repo for `CUSTOMIZE` and fill
      by hand.
-   - After the merge, review the drafted Epic and break it down into Task
-     issues — the `plan-management` skill (VS Code: `/breakdown-epic`);
-     full flow in step 6.
+   - After the merge, review the drafted Epics and break the first phase
+     down into Task issues — the `plan-management` skill (VS Code:
+     `/breakdown-epic`); full flow in step 6.
 
    *Done when:* `.github/scripts/tuning-status.sh` exits 0 on the merged main.
 3. **MCP** — interactive surfaces read `.vscode/mcp.json`; for the cloud
@@ -281,10 +281,10 @@ bash ≥ 3.2).
    - When decisions must outlive their tasks, run `/distill-context` →
      agreements PR → human merges (= agreement). Skip when there is nothing
      above the promotion bar yet — most knowledge rides in Task issues.
-   - Review the Epic drafted during onboarding — edit or replace it (form
-     or `templates/epic-body.md`) — then break it down (`plan-management`;
-     VS Code: `/breakdown-epic`) → approve → Task issues exist, wired and
-     routed.
+   - Review the Epics drafted during onboarding — edit or replace them (form
+     or `templates/epic-body.md`) — then break the first phase down
+     (`plan-management`; VS Code: `/breakdown-epic`) → approve → Task issues
+     exist, wired and routed.
    - Dispatch the frontier: `exec:cloud` → assign the issue to Copilot;
      `exec:app` → open a parent session with the **orchestrator** agent and
      let it spawn one child session per task (`/start-task` inside each);

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Onboarding now drafts one Epic per phase instead of a single Epic for the
+  whole project. The two skills contradicted each other — `plan-management`
+  asks for "Epics for the whole outline up front", `project-onboarding` said
+  "the outline Epic" — and the singular won in practice: one adoption ended
+  with nine phases inside one Epic, every later phase invisible, and the
+  natural-looking repair was a program Epic with phase Epics beneath it. The
+  graph has exactly two levels (Epic → Task), so that fix would have been
+  unsupported. Phase Epics are now siblings wired `blocked-by` in order; the
+  `/breakdown-epic` pointer, the deferred-from-onboarding ledger and the
+  closing handoff all ride the first phase's Epic, and a one-phase outline
+  still yields exactly one Epic. `plan-management` now states the sibling
+  rule outright rather than leaving it to be inferred (refs #22).
+
 - Decomposition now corrects the Epic's state line. Onboarding opens a draft
   Epic with "nothing is decomposed until you approve", but nothing ever
   removed that marker, so an Epic that had been reviewed, approved and split


### PR DESCRIPTION
Closes #22

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/22#issuecomment-5254915256

## What

`plan-management` asks for "Epics for the whole outline up front"; `project-onboarding` said "the outline Epic", singular. The singular won in practice: a real adoption ended with nine phases inside one Epic, every later phase invisible, and the repair that looked natural from there was a program Epic with nine phase Epics beneath it — a three-level graph the scaffold does not support.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| One Epic per phase, siblings | P2-close step now reads "one Epic per phase of the outline, as siblings; an Epic is never a sub-issue of another Epic" |
| Skills no longer contradict | `grep` cross-read: `plan-management` L38 "Epics for the whole outline up front … One Epic per phase, all siblings", `project-onboarding` L154–156 "Draft the **phase Epics** … one Epic per phase". `grep -rn 'the outline Epic\|the draft Epic\b\|drafted Epic\b\|the Epic URL\|Epic was skipped'` over `.github/` and README → no output |
| Ordering via `blocked-by` | Stated in both skills; the tracking-graph rule already forbids prose-only ordering |
| Only the first phase points at decomposition | The `/breakdown-epic` pointer rides the first phase's body; later phases "stay coarse until their turn and say so instead" |
| Draft marker and pointer still in bodies | Both retained, now applied per Epic — the existing rationale (chat handoff may not reach the reader) is unchanged |
| Single-phase projects unaffected | "A one-phase outline yields exactly one" |
| Adopter gets every URL | "Hand the adopter every Epic URL, first phase first" |
| Nothing suggests nested Epics | `plan-management` step 1 now says so outright rather than leaving it to the concept table |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (ceilings: onboarding 282/500, plan-management 211/500); run-tests.sh 15 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

## Deviations

Two places needed a decision rather than a plural rewrite, and both were resolved toward the **first phase's Epic**, stated inline so the choice is not silent:

1. **Deferred-from-onboarding ledger** — it records what onboarding could not finish, so it belongs to the Epic that is ready to move, not duplicated across every phase.
2. **Closing handoff** — it points at the one Epic that is ready to decompose.

Also updated README steps 2 and 6, which described the singular Epic; they were outside the issue's listed ownership but inside the same claim, and leaving them would have left the README contradicting the skills.
