### PR TITLE
Grant task-ritual contents: read so private checkouts work

### DIFF
--- a/.github/scripts/check-workflow-permissions.sh
+++ b/.github/scripts/check-workflow-permissions.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# check-workflow-permissions.sh — fail when a workflow job that declares its
+# own `permissions:` block runs `actions/checkout` without granting
+# `contents`.
+#
+# Why this guard exists: a job-level `permissions:` block *replaces* the
+# workflow-level grant, it does not merge with it. A job that lists only
+# `issues: read` therefore has no `contents` scope, and `actions/checkout`
+# fails with "Repository not found" — but only on private repositories,
+# because public ones clone without a token. This scaffold's own repository
+# is public, so its CI is structurally incapable of catching the mistake;
+# adopters on private repositories eat it on every pull request instead.
+# Hence a static check rather than trust in a green run.
+#
+# Scope: `.github/workflows/*.yml`. Jobs without a `permissions:` block are
+# skipped — they inherit the workflow-level grant, which is the common and
+# correct case.
+#
+# Output: brief OK summary and exit 0 when every such job grants contents;
+# the offending jobs and exit 1 otherwise.
+# Dependencies: bash 3.2+, awk only — no YAML parser, no network, so it runs
+# identically in CI and on a developer machine.
+set -euo pipefail
+
+DIR="${1:-.github/workflows}"
+[ -d "$DIR" ] || { echo "error: $DIR not found" >&2; exit 2; }
+
+findings=""
+checked=0
+
+for wf in "$DIR"/*.yml "$DIR"/*.yaml; do
+  [ -e "$wf" ] || continue
+  # One record per job: name, whether it declared permissions, whether that
+  # block granted contents, and whether the job checks the repository out.
+  report="$(awk '
+    # Job keys sit at exactly two spaces of indentation under `jobs:`.
+    /^  [a-zA-Z_][a-zA-Z0-9_-]*:[[:space:]]*$/ {
+      if (job != "") print job "\t" hasperm "\t" hascontents "\t" hascheckout
+      job = $1; sub(/:$/, "", job)
+      hasperm = 0; hascontents = 0; hascheckout = 0; inperm = 0
+      next
+    }
+    job == "" { next }
+    # `permissions:` on the job (four spaces). An inline empty map
+    # (`permissions: {}`) also counts as declared.
+    /^    permissions:/ { hasperm = 1; inperm = 1; next }
+    # Any other four-space key ends the permissions block.
+    /^    [a-zA-Z]/ { inperm = 0 }
+    inperm && /^      contents:/ { hascontents = 1 }
+    /actions\/checkout/ { hascheckout = 1 }
+    END { if (job != "") print job "\t" hasperm "\t" hascontents "\t" hascheckout }
+  ' "$wf")"
+
+  while IFS=$'\t' read -r job hasperm hascontents hascheckout; do
+    [ -n "$job" ] || continue
+    checked=$((checked + 1))
+    if [ "$hasperm" = "1" ] && [ "$hascheckout" = "1" ] && [ "$hascontents" = "0" ]; then
+      findings="${findings}${wf}: job '${job}' declares permissions and checks out"$'\n'"    the repository, but grants no 'contents' scope — checkout will fail"$'\n'"    on private repositories."$'\n'
+    fi
+  done <<EOF
+$report
+EOF
+done
+
+if [ -n "$findings" ]; then
+  printf 'FAIL: %s' "$findings"
+  echo "      A job-level permissions block replaces the workflow-level one."
+  echo "      Add 'contents: read' to each job listed above."
+  exit 1
+fi
+
+echo "check-workflow-permissions: OK — $checked job(s) checked; every job that declares permissions and checks out grants contents."

--- a/.github/scripts/tests/test-workflow-permissions.sh
+++ b/.github/scripts/tests/test-workflow-permissions.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test-workflow-permissions.sh — regression tests for
+# .github/scripts/check-workflow-permissions.sh.
+#
+# The guard catches a defect this repository's own CI cannot: a job that
+# declares `permissions:` without `contents` and then checks out fails only
+# on private repositories, while this repository is public. Each case writes
+# a throwaway workflow directory and asserts the exit code.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+GUARD="$REPO_ROOT/.github/scripts/check-workflow-permissions.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/wfpermtest.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# new_wf <case-name> <job-body> — build a one-job workflow directory and set
+# CASE_DIR to it.
+new_wf() {
+  CASE_DIR="$WORK/$1"
+  mkdir -p "$CASE_DIR"
+  {
+    printf 'name: t\non: [push]\npermissions:\n  contents: read\njobs:\n'
+    printf '%s\n' "$2"
+  } > "$CASE_DIR/wf.yml"
+}
+
+# --- the broken shape is caught -------------------------------------------
+new_wf broken '  ritual:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000000
+      - run: echo hi'
+expect_rc_grep 1 "grants no 'contents' scope" \
+  "job with permissions and checkout but no contents fails" \
+  bash "$GUARD" "$CASE_DIR"
+
+# --- the fixed shape passes -----------------------------------------------
+new_wf fixed '  ritual:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000000'
+expect_rc_grep 0 "check-workflow-permissions: OK" \
+  "job that grants contents passes" \
+  bash "$GUARD" "$CASE_DIR"
+
+# --- inheriting the workflow grant is fine --------------------------------
+# The common case: no job-level block, so the workflow-level grant applies.
+new_wf inherit '  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000000'
+expect_rc_grep 0 "check-workflow-permissions: OK" \
+  "job without a permissions block passes" \
+  bash "$GUARD" "$CASE_DIR"
+
+# --- permissions without checkout is fine ---------------------------------
+# Narrow scopes are correct when the job never clones; the guard must not
+# push `contents` onto jobs that do not need it.
+new_wf nocheckout '  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit 1 --add-label x'
+expect_rc_grep 0 "check-workflow-permissions: OK" \
+  "job with narrow permissions and no checkout passes" \
+  bash "$GUARD" "$CASE_DIR"
+
+# --- one bad job among good ones is still caught --------------------------
+new_wf mixed '  good:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000000
+  bad:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000000'
+expect_rc_grep 1 "job 'bad'" \
+  "a single offending job among healthy ones is reported" \
+  bash "$GUARD" "$CASE_DIR"
+
+# --- this repository's own workflows pass ---------------------------------
+expect_rc_grep 0 "check-workflow-permissions: OK" \
+  "the scaffold's own workflows pass the guard" \
+  bash "$GUARD" "$REPO_ROOT/.github/workflows"
+
+t_summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Action references are SHA-pinned
         run: bash .github/scripts/check-action-pins.sh
 
+      # A job-level permissions block replaces the workflow-level grant, so a
+      # job that checks out must repeat `contents: read`. The failure is
+      # invisible here — public repositories clone without a token — and only
+      # bites adopters on private ones, hence a static check.
+      - name: Job permissions cover checkout
+        run: bash .github/scripts/check-workflow-permissions.sh
+
       # Escalation-wording wall: failure budgets live only in the normative
       # skills; every other surface defers to the ladder without restating
       # counts (duplicated numbers drift from the design authority).
@@ -70,6 +77,12 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      # A job-level block replaces the workflow-level grant rather than
+      # adding to it, so `contents: read` has to be repeated here — without
+      # it `actions/checkout` fails with "Repository not found" on private
+      # repositories. Public repositories clone without a token, which is
+      # why this scaffold's own CI cannot catch the omission.
+      contents: read
       issues: read
       pull-requests: read
     steps:

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The `task-ritual` CI job can check out private repositories again. It
+  declared its own `permissions:` block, and a job-level block *replaces* the
+  workflow-level grant rather than merging with it — so `contents: read` was
+  lost and `actions/checkout` failed with "Repository not found" before the
+  guard ever ran. Public repositories clone without a token, so this
+  scaffold's own CI stayed green while every adopter on a private repository
+  saw a red check on every pull request. A new guard,
+  `check-workflow-permissions.sh`, fails CI when any job declares
+  `permissions:`, checks out, and omits `contents` — a static check, because
+  a public repository structurally cannot catch this class of defect by
+  running its own CI. Adopters already on private repositories pick the fix
+  up by re-running the installer with `--upgrade` (refs #24).
+
 - Onboarding now drafts one Epic per phase instead of a single Epic for the
   whole project. The two skills contradicted each other — `plan-management`
   asks for "Epics for the whole outline up front", `project-onboarding` said


### PR DESCRIPTION
Closes #24

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/24#issuecomment-5256590557

## What

`task-ritual` could not check out private repositories. Its job-level `permissions:` block replaced the workflow-level grant rather than merging with it, so `contents: read` was lost and `actions/checkout` failed with `Repository not found` (exit 128) before the ritual guard ran. Every adopter on a private repository saw a red check on every pull request.

Public repositories clone without a token, so this repository's own CI stayed green throughout — which is why the one-line fix comes with a guard.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Job checks out on private repositories | `contents: read` added to `task-ritual`, with a comment explaining the replace-not-merge behaviour |
| Least privilege kept | Exactly `contents: read` + the existing `issues: read` and `pull-requests: read`; nothing widened, nothing granted write |
| Every job audited | Walked all four workflows for "declares `permissions:` and runs `checkout`": `task-ritual` was the only offender; `copilot-setup-steps` already grants `contents: read`; `quality`, `scaffold-self-check`, `copilot-surface`, `hygiene` inherit; both `adopter-feedback` jobs never check out |
| Guard against recurrence | `check-workflow-permissions.sh` + `test-workflow-permissions.sh` (6 cases), wired into the quality job. Proven non-vacuous by reverting the fix and watching it report `job 'task-ritual' … grants no 'contents' scope` |
| Guard does not over-reach | Cases cover: no permissions block passes; narrow permissions without checkout passes; one bad job among healthy ones is still named |
| CHANGELOG, with upgrade note | SCAFFOLD-CHANGELOG.md Unreleased says adopters on private repositories pick the fix up via `--upgrade` |
| Verification wall | run-tests.sh 16 suites green (was 15); check-copilot-surface OK; check-action-pins OK; check-changelog-refs OK; `shellcheck -S style` clean |

## Deviations

None.

## Note

This is the second defect in two days that our own CI cannot observe, after the changelog references that only mis-resolve in a different repository. Both were caught by adopters. Worth remembering when weighing a green run as evidence: it certifies this repository, not every shape of adopter.
