### PR TITLE
Name skills, not slash commands, in agent-authored handoffs

### DIFF
--- a/.github/skills/plan-management/SKILL.md
+++ b/.github/skills/plan-management/SKILL.md
@@ -106,7 +106,7 @@ gh issue list --label "ai:ready" --state open --json number,title,labels
 Optional: visualize Epics and Tasks as spans on a Projects v2 roadmap. The
 board stays a *view* of the issue graph — fields are derived from issues,
 never the reverse (see the Portfolio view row in the Data model). Creation
-has an owner: the first decomposition (`/breakdown-epic`) checks for the
+has an owner: the first decomposition checks for the
 board and, when absent, offers `init` with one consent question — declining
 never blocks decomposition, and the board can still be attached manually
 any time.

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -60,8 +60,8 @@ plain `git push`; on any other branch put the scaffold commit on a branch
 cut from `origin/<default>` and push or PR-merge it to the default branch
 immediately — never sweep unrelated commits along, and never defer it to
 the P5 evidence PR. If the adopter declines, stop onboarding and note how
-to resume (land the scaffold on the default branch, re-run
-`/onboard-project`). If the push fails (no remote or no permission), record
+to resume (land the scaffold on the default branch, re-run the
+`project-onboarding` skill). If the push fails (no remote or no permission), record
 the blocker; you may continue same-checkout onboarding only after saying
 plainly that GitHub Actions, app/cloud sessions, and post-Epic task
 execution stay broken until the scaffold reaches the default branch.
@@ -94,7 +94,7 @@ discovered by P1/P3 or when work first needs it — path restrictions are
 declared per task in File ownership at decomposition time, secrets
 specifics surface when work first touches them (baseline guardrails
 already ship in the instructions), and the Projects roadmap board is
-offered by the first `/breakdown-epic` run (consent-gated), not
+offered by the first decomposition run (consent-gated), not
 interviewed up front. Every
 question must be answerable by a project owner without digging through
 the repository.
@@ -161,7 +161,8 @@ give the adopter something to review during it:
    handed-over documents by name. Open each body with a draft marker:
    *"Draft from onboarding — review and edit freely; nothing is decomposed
    until you approve."* End the **first phase's** body with the next-move
-   pointer: *"When this Epic looks right, run `/breakdown-epic` on it."* —
+   pointer: *"When this Epic looks right, decompose it with the
+   `plan-management` skill (in VS Code: `/breakdown-epic`)."* —
    the pointer rides in the body because the closing chat handoff may never
    reach whoever picks the Epic up. Later phases stay coarse until their
    turn and say so instead.
@@ -193,7 +194,8 @@ unrun command.
   user or team on every rule (clearing its `CUSTOMIZE:` sentinel) — a
   copied file that still names the template author cannot gate reviews.
 - Run `.github/scripts/setup-sources.sh` to activate the connector chosen
-  in P2 step 1 (records it in the SOURCES.md registry); `/kickoff-context` is
+  in P2 step 1 (records it in the SOURCES.md registry); the
+  `context-collection` skill (VS Code: `/kickoff-context`) is
   the follow-on that lands future context through it. Skip only when the
   adopter kept the default and no spec-kit workspace exists — then note
   the wizard can be run later.
@@ -243,13 +245,15 @@ report them *above* the block, never instead of it.
 1. Review and merge the evidence PR (the license merge).
 2. Review and edit the P2-close draft Epics — link them here, first phase
    first (or say they were skipped and point at the Epic form).
-3. When the first phase's Epic looks right, run `/breakdown-epic` on it —
-   decomposition into Task issues starts only on your approval, one phase
-   at a time; each ready Task then runs via `/start-task`.
+3. When the first phase's Epic looks right, decompose it with the
+   `plan-management` skill (VS Code: `/breakdown-epic`) — decomposition
+   into Task issues starts only on your approval, one phase
+   at a time; each ready Task then runs with the `session-orchestration`
+   skill (VS Code: `/start-task`).
 
 The same three moves ride durable carriers: the evidence PR description
 **ends with a `## Next steps` section**, and the first phase Epic's body
-already carries its `/breakdown-epic` pointer (P2-close). Durable copies exist
+already carries its decomposition pointer (P2-close). Durable copies exist
 because chat can die; the chat block exists because adopters read chat,
 not PR descriptions — neither substitutes for the other, and a PR
 announcement without the block is an unfinished P6. This checklist lives

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ bash ≥ 3.2).
    *Done when:* the board is visible in the repository's Projects tab.
 6. **First run:**
    - Collect sources into `.github/docs/context/<topic>/` (`context-collection`).
-   - When decisions must outlive their tasks, run `/distill-context` →
+   - When decisions must outlive their tasks, distill them
+     (`context-distillation`; VS Code: `/distill-context`) →
      agreements PR → human merges (= agreement). Skip when there is nothing
      above the promotion bar yet — most knowledge rides in Task issues.
    - Review the Epics drafted during onboarding — edit or replace them (form
@@ -287,10 +288,12 @@ bash ≥ 3.2).
      exist, wired and routed.
    - Dispatch the frontier: `exec:cloud` → assign the issue to Copilot;
      `exec:app` → open a parent session with the **orchestrator** agent and
-     let it spawn one child session per task (`/start-task` inside each);
+     let it spawn one child session per task (`session-orchestration`;
+     VS Code: `/start-task` inside each);
      `exec:ide` → a human pairs in the IDE (hardware work lands here).
-   - PRs flow through the gates; on deviations run `/replan`; periodically
-     run `/retro` so the system learns. Monthly, `retro-hygiene.yml` files
+   - PRs flow through the gates; on deviations replan (`plan-management`;
+     VS Code: `/replan`); periodically
+     run the `retro` skill (VS Code: `/retro`) so the system learns. Monthly, `retro-hygiene.yml` files
      a `Retro hygiene review <YYYY-MM>` issue surfacing promotion-overdue
      retro candidates and always-on budget drift.
    *Done when:* the first task PR merges with its evidence table — you have

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,20 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Agent-authored handoffs now name skills instead of VS Code-only commands.
+  An earlier pass fixed the README, the installer banner and the Epic
+  template, but stopped short of the text agents *write*: the pointer
+  embedded in every drafted Epic body, the closing handoff block, and the
+  remaining prose references. An adopter running onboarding in a Copilot app
+  session was told to "run `/breakdown-epic`" and "`/start-task`" — neither
+  exists on that surface, and no skill answers to those names either
+  (`plan-management` serves decomposition and replanning,
+  `session-orchestration` serves task start). The Epic-body pointer mattered
+  most: it is committed to GitHub and read by whoever opens the issue later.
+  The README's first-run flow is corrected too; the lifecycle table and repo
+  map still name the prompt files, where they are the subject rather than an
+  instruction (refs #25).
+
 - The `task-ritual` CI job can check out private repositories again. It
   declared its own `permissions:` block, and a job-level block *replaces* the
   workflow-level grant rather than merging with it — so `contents: read` was


### PR DESCRIPTION
Closes #25

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/25#issuecomment-5256702889

## What

Agent-authored text still told humans to run `/breakdown-epic` and `/start-task`. Those are VS Code Copilot Chat prompt files — not commands in a Copilot app session or CLI — and no skill answers to those names either. An adopter received exactly that instruction at the end of onboarding.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Epic-body pointer names the skill | Now written as *"When this Epic looks right, decompose it with the `plan-management` skill (in VS Code: `/breakdown-epic`)."* — the highest-value fix, since this line is committed to GitHub |
| Closing handoff works on any surface | Step 3 names `plan-management` for decomposition and `session-orchestration` for task start, each with its VS Code shortcut |
| Remaining prose references corrected | `project-onboarding` L64 (resume instruction), L97 (board offer), L198 (context follow-on), L256 (durable carriers); `plan-management` L109 (board ownership) |
| Skill names are correct | `plan-management` for decomposition and replanning, `session-orchestration` for task start, `context-collection` / `context-distillation` for the context prompts |
| No prompt renamed, moved or deleted | `.github/prompts/**` untouched |
| Grep cross-read clean | Every surviving slash reference is either a VS Code shortcut note or a repo-map / lifecycle-table entry where the prompt file is the subject |
| README first-run flow | L282 (`context-distillation`), L287 (`plan-management`), L292 (`session-orchestration`), L295 (`plan-management` / `retro`) |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (ceilings 286/500 and 211/500); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK; check-workflow-permissions OK |

## Deviations

Two beyond the issue's list, both found by the cross-read rather than the line inventory:

1. `project-onboarding` L64 — the "how to resume" instruction after a declined push also named `/onboard-project`. It is read by a human at the moment onboarding stops, so leaving it would have failed the same acceptance criterion.
2. `.github/ISSUE_TEMPLATE/epic.yml` needed no change: the earlier pass had already corrected it, and the surviving `/breakdown-epic` there is the shortcut half of the intended phrasing.
