### PR TITLE
Explain gated cloud CI in the parent-session protocol

### DIFF
--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -197,6 +197,15 @@ You are the WORKER session for Task issue #<n> in <owner>/<repo>.
    `.github/skills/task-routing/SKILL.md`.
    Dispatching a `risk:high` task? Its child pauses after the plan comment —
    review promptly and reply with an approval (or steer) to release it.
+   A dispatched cloud task whose PR shows *no* checks has usually not
+   failed: many organizations gate workflow runs from this class of actor,
+   leaving every run at `action_required` until someone approves it from
+   the repository's Actions tab. Read the agent's own run before concluding
+   anything — `gh run list` showing `Running Copilot cloud agent → success`
+   next to `CI → action_required` means the work landed and only CI is
+   waiting. The gate is an organization Actions policy, not a repository
+   setting, so it cannot be cleared from here; where no such policy exists,
+   nothing appears and there is nothing to do.
 2. **Issue-first, dedicated-session — no exceptions for infra/ops.** Ad-hoc
    requests (e.g. a human asking "can you deploy this?"), and cloud/deploy/
    infra work in general (provisioning, secrets, deploy unblocking), get a

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The parent-session protocol now explains gated cloud CI. A dispatched
+  `exec:cloud` task can finish correctly — agent run green, draft PR opened,
+  fix included — while every check on that PR sits at `action_required`,
+  because many organizations gate workflow runs from this class of actor.
+  `gh pr checks` then reports "no checks reported", which reads as CI never
+  firing, and an adopter concluded the cloud agent had errored when it had
+  not. The dispatch step now names the two states and the diagnostic that
+  separates them (read the agent's own run, not just the PR's checks), and
+  says the gate is an organization Actions policy rather than a repository
+  setting — so adopters stop looking for a switch the scaffold could have
+  flipped. Where no such policy exists nothing appears (refs #28).
+
 - Agent-authored handoffs now name skills instead of VS Code-only commands.
   An earlier pass fixed the README, the installer banner and the Epic
   template, but stopped short of the text agents *write*: the pointer


### PR DESCRIPTION
Closes #28

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/28#issuecomment-5257116527

## What

An `exec:cloud` task on a real adoption ran to completion — agent run `success`, draft PR opened with the fix — but every CI check on that PR sat at `action_required`, so `gh pr checks` reported "no checks reported". The adopter read that as the cloud agent having errored. Nothing in the scaffold said otherwise.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Adopter can find out what it means and how to clear it | Parent session protocol step 1 now covers it: gated runs, approving from the Actions tab |
| Two states clearly distinguished | "A dispatched cloud task whose PR shows *no* checks has usually not failed" + the diagnostic: `Running Copilot cloud agent → success` next to `CI → action_required` means the work landed |
| Remedy stated concretely | Approve from the repository's Actions tab; the policy itself is organization-level |
| Guidance sits on the dispatch path | Immediately after the `exec:cloud` dispatch step, where a reader watching a cloud task already is — not in a README appendix |
| Accurate for ungated organizations | "where no such policy exists, nothing appears and there is nothing to do" |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (310/500 lines); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

## Deviations

The issue listed `task-routing/SKILL.md` first and `session-orchestration/SKILL.md` as a fallback; the note went to `session-orchestration` alone. `task-routing` answers "which surface should this run on", decided at planning time, while this symptom appears after dispatch, when someone is watching a running task — which is the parent-session protocol's territory.

The claim that this is an organization policy rather than a repository setting was checked rather than assumed: `actions/permissions/workflow` and `actions/permissions/access` return identical values on the affected repository and on this one, where no gate appears.
