### PR TITLE
Add the program session layer above Epic sessions

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-description: Parent-session conductor. Computes the actionable frontier from the issue graph, dispatches Task issues to child sessions or the cloud agent, steers running work, independently verifies reports, and keeps GitHub Issues/Projects synchronized with reality. Never writes application code.
+description: Conductor session, at either layer — program (starts each Epic's session as its phase comes up, watches across phases, replans the outline) or Epic parent (computes the actionable frontier, dispatches Task issues to child sessions or the cloud agent, steers running work, independently verifies reports, keeps GitHub Issues/Projects synchronized with reality). Never writes application code.
 # Tool aliases per GitHub Docs "Custom agents configuration"
 # (docs.github.com/en/copilot/reference/custom-agents-configuration):
 # no `edit` — the orchestrator conducts and verifies, it never edits files;
@@ -9,8 +9,13 @@ description: Parent-session conductor. Computes the actionable frontier from the
 tools: ["read", "search", "execute", "agent", "github/*"]
 ---
 
-You are the orchestrator: the parent session that runs the delivery loop for
-one Epic. You coordinate; you do not implement. If you find yourself editing
+You are the orchestrator. You conduct; you do not implement. The role runs at
+two layers, and the session you are in decides which: as a **program
+session** you conduct the whole Epic set — starting each Epic's session when
+its phase comes up, watching across phases, replanning when the outline
+diverges (`session-orchestration` §Program session protocol). As an **Epic's
+parent session** you run the delivery loop below for that one Epic. Either
+way, if you find yourself editing
 application source code, stop — that work belongs in a child Task session.
 Infra/cloud/deploy work (provisioning, secrets, deploy unblocking, smoke
 tests) is no exception: never execute it inline. Create or locate its Task
@@ -22,7 +27,7 @@ Follow `AGENTS.md` and these skills as your operating manual:
 `.github/skills/session-orchestration/SKILL.md` (dispatch/report protocol),
 `.github/skills/task-routing/SKILL.md` (where each task should run).
 
-## Loop
+## Loop (Epic parent session)
 
 1. **Frontier.** Determine which Task issues are actionable now: open, labeled
    `ai:ready`, all blockers closed (use

--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -15,6 +15,7 @@ record on GitHub while using sessions for speed.
 
 | Plan object | Session object | Workspace object |
 |---|---|---|
+| The Epic set (whole project) | One program session (conductor of conductors) | — |
 | Epic issue | Parent (orchestrator) session | — |
 | Task issue | One supervisor session (ritual only, no code edits) | — |
 | Pull request | One active worker session | One worktree + branch `task/<n>-<slug>` (or accepted tool-prefixed variant) |
@@ -188,6 +189,33 @@ You are the WORKER session for Task issue #<n> in <owner>/<repo>.
 - Do NOT post comments on the issue; report to your supervisor session and stop.
 ```
 
+## Program session protocol
+
+One program session per project, started when the phase Epics first exist
+(onboarding drafts them) and kept for the life of the plan. It conducts
+conductors: it never decomposes, dispatches Tasks, or edits code itself.
+
+1. **Start an Epic's session when that phase's turn comes** — when its
+   `blocked-by` Epics are closed, or the frontier has run dry. Hand it the
+   Epic number and nothing else; the Epic is the brief.
+2. **Epic sessions are siblings, not descendants.** An Epic session that
+   sees the next phase becoming actionable reports that to the program
+   session rather than starting a peer itself: sessions spawning their
+   successors nest one level deeper per phase, and after a few phases the
+   tree is unreadable. Epics are siblings in the issue graph; their sessions
+   mirror that.
+3. **Watch across Epics, not within one.** Phase-spanning trouble is the
+   program session's business: an Epic whose blockers never clear, a
+   dependency that turns out to be backwards, repeated escalations of the
+   same shape. Within an Epic, its own session decides.
+4. **Replan across phases** (`plan-management` skill) when reality diverges
+   from the outline — reordering phases, splitting one, dropping another.
+   Record the rationale on the affected Epic, not in session memory.
+5. **Ending.** Program sessions die like any other: before one ends, the
+   state of play must be legible from GitHub alone — each Epic's status
+   visible from its issue, its comments, and the board. Whoever restarts a
+   program session reads the graph, not the transcript.
+
 ## Parent session protocol
 
 1. Dispatch only from the frontier (`plan-management` skill), after checking
@@ -227,6 +255,12 @@ You are the WORKER session for Task issue #<n> in <owner>/<repo>.
    with one instruction: record first.
 6. Route `needs-replan` outcomes to the planner procedure
    (`plan-management` §Replanning) and post the rationale on the Epic.
+7. When the Epic's phase is done — its Tasks closed, their PRs merged, the
+   Epic's own state line current — tell the program session so the next
+   phase gets a session. Do not start that session yourself: the program
+   session keeps Epic sessions siblings (see Program session protocol). If
+   no program session is running, say so in the Epic's closing comment and
+   name the next Epic, so a human or a fresh program session can pick it up.
 
 ## Copilot app session tree
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The session model gains a program layer, so the next phase has an owner.
+  The mapping table bound an Epic to a parent session, but nothing said how
+  one starts — an adopter finishing a phase had no stated next move, and
+  phase-level decisions landed in whichever session happened to be open. A
+  program session now sits above the Epic sessions: it starts each one as
+  its phase comes up, watches across phases, and replans the outline when
+  reality diverges. Epic sessions report upward instead of spawning their
+  successors, which keeps them siblings — mirroring the issue graph, where
+  Epics are siblings too, and keeping the session tree at a constant depth
+  rather than one level deeper per phase. The `orchestrator` agent already
+  described this conductor and only scoped itself to one Epic; it now covers
+  both layers (refs #29).
+
 - The parent-session protocol now explains gated cloud CI. A dispatched
   `exec:cloud` task can finish correctly — agent run green, draft PR opened,
   fix included — while every check on that PR sits at `action_required`,


### PR DESCRIPTION
Closes #29

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/29#issuecomment-5260927265

## What

`session-orchestration` mapped an Epic to a parent session in one table row and never said how one begins. An adopter who finished a phase asked the obvious question — "how does the next Epic get started?" — and the scaffold had no answer, so work continued wherever the human happened to be typing.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| When a parent session starts, and its first move | Program session protocol step 1: started when its `blocked-by` Epics close or the frontier runs dry; handed the Epic number and nothing else |
| What it owns and does not | Program: starts Epic sessions, watches across phases, replans the outline; explicitly never decomposes, dispatches Tasks, or edits code. Within an Epic, that Epic's session decides |
| When it ends, and what must be on GitHub first | Step 5: the state of play must be legible from the issues, comments and board alone — "whoever restarts a program session reads the graph, not the transcript" |
| Next Epic reachable from the end of the previous phase | Parent session protocol gains step 7: on phase completion, report to the program session; if none is running, name the next Epic in the closing comment so a human or fresh program session picks it up |
| Surface-neutral | Described as "start a session for the Epic"; no app-specific button or tool named |
| Consistent with existing rules | One Task = one supervisor session is untouched; rolling-wave is untouched — the program session starts *sessions*, it does not decompose |
| Orchestrator role updated | Frontmatter and opening now cover both layers; the delivery loop is retitled "Loop (Epic parent session)" so it is clear which layer it belongs to |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (session-orchestration 344/500, orchestrator 66); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK; check-workflow-permissions OK |

## Deviations

None. The design was settled with the requester before writing, and two alternatives were rejected on record so they are not re-litigated later:

- **Epic session spawns the next Epic session.** Works, but the tree deepens by one level per phase.
- **A human creates each Epic session by hand.** Simplest structure, but leaves the hand-off unowned — which is the defect being fixed.

Worth noting what this did *not* require: the `orchestrator` agent already described a conductor that starts sessions and watches a graph. The gap was a missing layer, not a missing role.
