### PR TITLE
Fail setup-project.sh up front when gh is unauthenticated

### DIFF
--- a/.github/scripts/setup-project.sh
+++ b/.github/scripts/setup-project.sh
@@ -79,6 +79,13 @@ usage_error() {
 require_tools() {
   command -v gh >/dev/null 2>&1 || fail "gh CLI not found on PATH"
   command -v jq >/dev/null 2>&1 || fail "jq not found on PATH"
+  # Probe the token, not just the binary: an unauthenticated gh otherwise
+  # fails later inside a project API call, where the error names the call
+  # rather than the cause. Same probe and wording as the sibling setup
+  # scripts.
+  gh api user --jq .login >/dev/null 2>&1 \
+    || fail "gh is not authenticated
+  fix: run: gh auth login"
 }
 
 REPO=""

--- a/.github/scripts/tests/test-setup-project.sh
+++ b/.github/scripts/tests/test-setup-project.sh
@@ -39,9 +39,15 @@ case "${1:-}" in
     esac
     ;;
   api)
-    # The only GraphQL reads/writes the script makes on the project surface.
+    # `$*` still holds the leading `api`, so match on the path that follows.
     args="$*"
     case "$args" in
+      "api user"*)
+        # The auth preflight probes `gh api user`. AUTHED=0 models an
+        # unauthenticated gh, which the real CLI reports as a failed call.
+        [ "${AUTHED:-1}" = "1" ] || exit 1
+        printf 'octocat\n'
+        ;;
       *createProjectV2View*)
         [ "${CREATE_FAILS:-0}" = "1" ] && exit 1
         printf '%s\n' "$args" >> "$CREATED_LOG"
@@ -64,7 +70,7 @@ PATH="$WORK/bin:$PATH"
 export PATH
 
 run_init() {
-  VIEWS_FIXTURE="$1" CREATED_LOG="$2" CREATE_FAILS="${3:-0}" \
+  VIEWS_FIXTURE="$1" CREATED_LOG="$2" CREATE_FAILS="${3:-0}" AUTHED="${AUTHED:-1}" \
     bash "$SCRIPT" init --owner o -R o/r 2>&1
 }
 
@@ -131,6 +137,35 @@ if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -q 'warning: could not create'
   t_ok "a refused view creation warns and setup still completes"
 else
   t_fail "a refused view creation warns and setup still completes (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+
+# --- unauthenticated gh stops the run at the preflight ---------------------
+# Without this guard the script proceeds and fails later inside a project API
+# call, where the error names the call rather than the cause. The three
+# sibling setup scripts have had this probe all along.
+: > "$WORK/views-auth.txt"
+: > "$WORK/created-auth.log"
+out=$(AUTHED=0 run_init "$WORK/views-auth.txt" "$WORK/created-auth.log")
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'gh is not authenticated'; then
+  t_ok "unauthenticated gh fails at the preflight"
+else
+  t_fail "unauthenticated gh fails at the preflight (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+if printf '%s\n' "$out" | grep -q 'gh auth login'; then
+  t_ok "the preflight names the fix"
+else
+  t_fail "the preflight names the fix"
+fi
+# Stopping *before* any project call is the point: a guard that fires after
+# the board is half-built is not a preflight.
+if [ ! -s "$WORK/created-auth.log" ] \
+   && ! printf '%s\n' "$out" | grep -q 'Reusing project\|Created DATE field'; then
+  t_ok "the preflight stops before touching the project"
+else
+  t_fail "the preflight stops before touching the project"
   printf '%s\n' "$out" | sed 's/^/    # /'
 fi
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,13 @@ inherit what this one learned.
 
 ### Unreleased
 
+- `setup-project.sh` now fails up front when `gh` is not authenticated,
+  matching the three sibling setup scripts. It was the only one without the
+  probe, so an unauthenticated run got as far as a project API call and
+  failed there, reporting the call rather than the cause. The check lives in
+  the existing `require_tools()`, so every subcommand is covered, and the
+  message is byte-identical to the other scripts (refs #5).
+
 - The session model gains a program layer, so the next phase has an owner.
   The mapping table bound an Epic to a parent session, but nothing said how
   one starts — an adopter finishing a phase had no stated next move, and


### PR DESCRIPTION
Closes #5

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/5#issuecomment-5263030972

## What

`setup-project.sh` was the only setup script without an authentication preflight. An unauthenticated run got as far as a project API call and failed there, naming the call instead of the cause.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Fails before doing any work | Probe added to `require_tools()`, which every subcommand already calls. Test asserts the run stops before any project call: nothing written to the creation log, and no `Reusing project` / `Created DATE field` output |
| Same message shape as the siblings | Ran both `setup-project.sh` and `setup-labels.sh` against a stubbed unauthenticated `gh`; both print `error: gh is not authenticated` then `  fix: run: gh auth login` — identical output |
| Verbatim adaptation, no new dependency | Same probe the siblings use (`gh api user --jq .login`), routed through this script's existing `fail()` |
| Regression test | Three cases in `test-setup-project.sh`: non-zero exit with the guard message, the fix is named, and the run stops before touching the project. Proven non-vacuous by deleting the guard and watching all three turn red |
| Picked up by `run-tests.sh` | 16 suites green; the file is discovered automatically |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | run-tests.sh green; check-copilot-surface OK; check-changelog-refs OK; check-workflow-permissions OK; `shellcheck -S style` clean |

## Deviations

The issue expected a new `test-setup-project.sh`; #18 had already created it, as that issue anticipated, so this change extends it (5 cases → 8).

Its `gh` shim needed two fixes to make the case meaningful. It answered unmatched `api` calls with a silent success, so the preflight would have passed no matter what — the test would have been vacuous. Adding an explicit `api user` branch exposed a second bug: the shim matched on `$*`, which still holds the leading `api`, so the pattern never fired. Both are fixed, and the false-green check above confirms the case now fails when the guard is removed.
