### PR TITLE
Say the Copilot app is required, not one surface among several

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Agentic Development Scaffold (GitHub-native)
 
 Repository wiring for running an AI-agent development lifecycle on GitHub —
-with GitHub Copilot cloud (coding) agent, the GitHub Copilot app's
-parent/child sessions, Copilot CLI, and IDE agents — such that **the plan,
+conducted from the **GitHub Copilot app**, whose parent/child sessions carry
+the orchestration model, with the Copilot cloud (coding) agent, Copilot CLI
+and IDE agents executing individual tasks — such that **the plan,
 the work, the evidence, and the lessons all live on GitHub**, not in chat
 windows. Everything here is plain files: version it, review it, and let the
 improvement loops evolve it.
@@ -141,9 +142,11 @@ degrades every request a little.
 ## Getting started
 
 **Prerequisites:** `gh` (authenticated — check with `gh auth status`; the
-setup scripts refuse to run without it), `jq`, and GitHub Copilot access
-on at least one surface (VS Code Copilot Chat, Copilot CLI, or a GitHub
-Copilot app session).
+setup scripts refuse to run without it), `jq`, and the **GitHub Copilot
+app** — the lifecycle runs on its session hierarchy (a program session
+starts each Epic's session, which supervises its Tasks), which no other
+surface provides. Copilot CLI and IDE chat execute individual tasks
+alongside it; they are not substitutes for the app.
 
 **Supported plans:** public repositories work on any GitHub plan; private
 ones require a paid plan (the scaffold relies on features that need one),
@@ -212,8 +215,9 @@ bash ≥ 3.2).
    *Done when:* `.github/scripts/tuning-status.sh` lists the pristine `CUSTOMIZE`
    markers and exits non-zero — the untuned state is machine-visible.
 2. **Onboard** — run the `project-onboarding` skill in a Copilot app
-   session, Copilot CLI, or VS Code Copilot Chat; in VS Code the shortcut
-   `/onboard-project` does the same.
+   session. (The skill also loads in Copilot CLI and VS Code Copilot Chat,
+   where `/onboard-project` is a shortcut for it — but the loop it hands you
+   off to needs the app's sessions.)
 
    - It inventories the repo, asks only the gaps, verifies commands by
      running them, and fills or removes every `CUSTOMIZE` block across

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ without a human in the loop.
 | Phase | What happens | Lives in |
 |---|---|---|
 | 0. Onboard | Tune the scaffold to the project: inventory → gap interview → run-verified commands → fill every CUSTOMIZE → evidence PR | `project-onboarding` skill, `tuning-status.sh` |
-| 1. Collect | Land raw information with provenance — *pluggable via context connectors* (`.github/connectors/`): the built-in interview flow is the default, an existing spec-kit workspace can be adopted instead | `.github/docs/context/` via `context-collection` skill; `/kickoff-context` prompt; `setup-sources.sh` wizard |
+| 1. Collect | Land raw information with provenance — *pluggable via context connectors* (`.github/connectors/`): the built-in interview flow is the default, an existing spec-kit workspace can be adopted instead | `.github/docs/context/` via `context-collection` skill; `setup-sources.sh` wizard |
 | 2. Distill & agree | Turn raw material into reviewed truth (REQ/ADR/glossary/non-goals) via PR — *only when a decision must outlive its task* (promotion bar in the skill); place each piece of knowledge in a context tier. With a non-builtin connector, the enabled source satisfies the same Context Contract | `.github/docs/agreements/` via `context-distillation` skill; contract in `.github/connectors/README.md` |
 | 3. Plan & orchestrate | Rolling-wave issue graph (Epics → just-in-time Task sub-issues, `blocked-by` ordering, actionable frontier); parent/child sessions execute it | `plan-management` + `session-orchestration` skills, issue templates |
 | 4. Route & execute | Each task carries one `exec:*` label + Routing block deciding surface, role, and model tier | `task-routing` skill, `.github/agents/` |
@@ -70,10 +70,8 @@ docs/                              This repository's own development records: co
     session-orchestration/           parent/child session protocol
     verification/                    gates, evidence, CI-failure triage
     retro/                           failures -> system improvements (+ upstreaming)
-  prompts/                         VS Code Copilot Chat shortcuts to the skills above:
-                                   /onboard-project /kickoff-context
-                                   /distill-context /breakdown-epic /start-task
-                                   /replan /retro
+  prompts/                         VS Code Copilot Chat shortcuts to the skills
+                                   above (the app loads the skills directly)
   connectors/                      Context connectors: Contract + conformance rules
                                    (README.md), builtin + speckit definitions, template
   ISSUE_TEMPLATE/                  Web forms mirroring the canonical bodies
@@ -215,9 +213,7 @@ bash ≥ 3.2).
    *Done when:* `.github/scripts/tuning-status.sh` lists the pristine `CUSTOMIZE`
    markers and exits non-zero — the untuned state is machine-visible.
 2. **Onboard** — run the `project-onboarding` skill in a Copilot app
-   session. (The skill also loads in Copilot CLI and VS Code Copilot Chat,
-   where `/onboard-project` is a shortcut for it — but the loop it hands you
-   off to needs the app's sessions.)
+   session.
 
    - It inventories the repo, asks only the gaps, verifies commands by
      running them, and fills or removes every `CUSTOMIZE` block across
@@ -231,8 +227,8 @@ bash ≥ 3.2).
      merge**). Manual fallback: search the repo for `CUSTOMIZE` and fill
      by hand.
    - After the merge, review the drafted Epics and break the first phase
-     down into Task issues — the `plan-management` skill (VS Code:
-     `/breakdown-epic`); full flow in step 6.
+     down into Task issues with the `plan-management` skill; full flow in
+     step 6.
 
    *Done when:* `.github/scripts/tuning-status.sh` exits 0 on the merged main.
 3. **MCP** — interactive surfaces read `.vscode/mcp.json`; for the cloud
@@ -283,21 +279,19 @@ bash ≥ 3.2).
 6. **First run:**
    - Collect sources into `.github/docs/context/<topic>/` (`context-collection`).
    - When decisions must outlive their tasks, distill them
-     (`context-distillation`; VS Code: `/distill-context`) →
+     (`context-distillation`) →
      agreements PR → human merges (= agreement). Skip when there is nothing
      above the promotion bar yet — most knowledge rides in Task issues.
    - Review the Epics drafted during onboarding — edit or replace them (form
      or `templates/epic-body.md`) — then break the first phase down
-     (`plan-management`; VS Code: `/breakdown-epic`) → approve → Task issues
+     (`plan-management`) → approve → Task issues
      exist, wired and routed.
    - Dispatch the frontier: `exec:cloud` → assign the issue to Copilot;
      `exec:app` → open a parent session with the **orchestrator** agent and
-     let it spawn one child session per task (`session-orchestration`;
-     VS Code: `/start-task` inside each);
+     let it spawn one child session per task (`session-orchestration`);
      `exec:ide` → a human pairs in the IDE (hardware work lands here).
-   - PRs flow through the gates; on deviations replan (`plan-management`;
-     VS Code: `/replan`); periodically
-     run the `retro` skill (VS Code: `/retro`) so the system learns. Monthly, `retro-hygiene.yml` files
+   - PRs flow through the gates; on deviations replan (`plan-management`);
+     periodically run the `retro` skill so the system learns. Monthly, `retro-hygiene.yml` files
      a `Retro hygiene review <YYYY-MM>` issue surfacing promotion-overdue
      retro candidates and always-on budget drift.
    *Done when:* the first task PR merges with its evidence table — you have

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,16 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
-- The README no longer presents Copilot CLI and IDE chat as alternatives to
-  the GitHub Copilot app. Prerequisites said Copilot access "on at least one
-  surface" would do, which is plainly false: the lifecycle runs on the app's
-  session hierarchy — a program session starting each Epic's session, which
+- The README now reads as documentation for a kit used **in the GitHub
+  Copilot app**. Prerequisites said Copilot access "on at least one surface"
+  would do, which is plainly false: the lifecycle runs on the app's session
+  hierarchy — a program session starting each Epic's session, which
   supervises its Tasks — and no other surface can spawn a session or receive
-  a report from one. The opening paragraph, Prerequisites and Getting started
-  step 2 now name the app as required and say why in one clause. What CLI and
-  IDE chat actually do is unchanged and still visible: they execute
-  individual tasks, and `exec:ide` remains the route for work that wants a
-  human at the keyboard or physical hardware (refs #33).
+  a report from one. The opening paragraph, Prerequisites and Getting
+  started now name the app as required and say why, and the VS Code slash
+  shortcuts are gone from the walkthrough: the README names skills, which is
+  what an app session loads. The prompt files keep one line in the
+  repository map, where they are the subject rather than an instruction.
+  What CLI and IDE chat actually do is unchanged and still visible: they
+  execute individual tasks, and `exec:ide` remains the route for work that
+  wants a human at the keyboard or physical hardware (refs #33).
 
 - `setup-project.sh` now fails up front when `gh` is not authenticated,
   matching the three sibling setup scripts. It was the only one without the

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,17 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The README no longer presents Copilot CLI and IDE chat as alternatives to
+  the GitHub Copilot app. Prerequisites said Copilot access "on at least one
+  surface" would do, which is plainly false: the lifecycle runs on the app's
+  session hierarchy — a program session starting each Epic's session, which
+  supervises its Tasks — and no other surface can spawn a session or receive
+  a report from one. The opening paragraph, Prerequisites and Getting started
+  step 2 now name the app as required and say why in one clause. What CLI and
+  IDE chat actually do is unchanged and still visible: they execute
+  individual tasks, and `exec:ide` remains the route for work that wants a
+  human at the keyboard or physical hardware (refs #33).
+
 - `setup-project.sh` now fails up front when `gh` is not authenticated,
   matching the three sibling setup scripts. It was the only one without the
   probe, so an unauthenticated run got as far as a project API call and


### PR DESCRIPTION
Closes #33

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/33#issuecomment-5263706764

## What

The README listed the Copilot app, Copilot CLI and VS Code Copilot Chat as interchangeable ways to run this kit, and Prerequisites went as far as "access on at least one surface". The orchestration model depends on the app's session hierarchy, so that was wrong in a way an adopter would only discover after installing.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| App stated as required, with the reason | Prerequisites: "the **GitHub Copilot app** — the lifecycle runs on its session hierarchy (a program session starts each Epic's session, which supervises its Tasks), which no other surface provides" |
| "At least one surface" gone | That sentence is replaced; `grep` finds no remaining claim that any single surface suffices |
| Getting started names the app | Step 2 runs onboarding in an app session; the CLI/VS Code note is explicitly about the skill loading there, with the caveat that the loop it hands off to needs the app's sessions |
| CLI and IDE keep an honest role | Opening paragraph: they execute individual tasks. `exec:cli` / `exec:ide` untouched at L115–116 and L297, including "a human pairs in the IDE (hardware work lands here)" |
| Cloud agent still visible | Named in the opening paragraph among the executors |
| Documentation only | Diff is README + changelog; no skill, prompt or routing label touched |
| Reader learns it before installing | Prerequisites is L144, the installer command L171 — the requirement is on the way in, not after |
| Verification wall | check-md-links OK; check-copilot-surface OK; run-tests.sh 16 suites green; check-changelog-refs OK; check-escalation-wording OK |

## Scope change during the task

After reviewing the first pass, the requester widened the ask: rather than correcting the three misleading sites, the README should read throughout as documentation for a kit used **in the app**. So the six `(VS Code: /command)` shortcut notes were removed as well — a reader in an app session cannot use them, and #25 already settled that skills are the portable layer. The prompt files keep one line in the repository map, where they are the subject rather than an instruction.

`grep` for the seven slash commands across README.md now returns 0; the three remaining mentions of CLI / VS Code all sit in the "app conducts, others execute" framing.

## Deviations

None.

