### PR TITLE
Name sessions after the work they carry

### DIFF
--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -197,7 +197,8 @@ conductors: it never decomposes, dispatches Tasks, or edits code itself.
 
 1. **Start an Epic's session when that phase's turn comes** — when its
    `blocked-by` Epics are closed, or the frontier has run dry. Hand it the
-   Epic number and nothing else; the Epic is the brief.
+   Epic number and nothing else; the Epic is the brief. Name it `Epic #<n>`
+   (session naming: §Copilot app session tree).
 2. **Epic sessions are siblings, not descendants.** An Epic session that
    sees the next phase becoming actionable reports that to the program
    session rather than starting a peer itself: sessions spawning their
@@ -241,7 +242,8 @@ conductors: it never decomposes, dispatches Tasks, or edits code itself.
    session like any other task — never inline in the parent. No issue, no
    work: evidence recorded after the fact on a closed issue does not count.
 3. When dispatching a **supervisor**, pass the issue number only — the
-   issue is the brief. If
+   issue is the brief, and name the session `Task #<n> supervisor`
+   (workers: `PR #<n> worker`; naming rule in §Copilot app session tree). If
    you feel the need to add substantial instructions in the dispatch message,
    the brief is incomplete: fix the issue first. Supervisor→worker kickoffs
    are the exception: they use the complete Worker kickoff template above,
@@ -276,6 +278,13 @@ tree. Two structural facts shape it:
   creator in the sidebar. The tree shape is grouping, not memory: roles are
   portable (§1), and a dead session at any tier is replaced by a successor
   resuming from the ledger.
+
+**Name sessions after what they work on**, so a sidebar of open sessions can
+be read without opening any of them: `Program`, `Epic #1`, `Task #6
+supervisor`, `PR #12 worker`. Keep the `#` — a bare number could be anything,
+and a worker's PR number is not its Task's. Issue titles stay out: names are
+display strings in a narrow column, where short and uniform beats descriptive
+and truncated.
 
 App tools that instantiate the protocol:
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,17 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Sessions now have a naming convention: `Program`, `Epic #1`, `Task #6
+  supervisor`, `PR #12 worker`. Nothing said how to name a session, so agents
+  labelled them by role — `Task 6 supervisor` — and a sidebar of open
+  sessions read as a list of numbered roles with no way to tell which issue
+  each one served. Keeping the `#` is the point: a bare number could be
+  anything, and a worker's PR number is not its Task's. Issue titles stay
+  out deliberately, since session names are display strings in a narrow
+  column where short and uniform beats descriptive and truncated. The rule
+  is stated where sessions are created and referenced from both dispatch
+  steps (refs #37).
+
 - Agent-authored text no longer offers VS Code shortcuts. The README dropped
   them when the Copilot app became the stated requirement, but the skills,
   the Epic template and the installer banner stayed on the older convention


### PR DESCRIPTION
Closes #37

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/37#issuecomment-5269441022

## What

Sessions were named by role — `Task 6 supervisor` — which says what a session is but not what it works on. With several open, the sidebar becomes a list of numbered roles and the human has to open each one to find the work they care about. No naming rule existed anywhere in the scaffold, so the role was the natural label for an agent to pick.

| Layer | Name |
|---|---|
| Program | `Program` |
| Epic parent | `Epic #1` |
| Task supervisor | `Task #6 supervisor` |
| Worker | `PR #12 worker` |

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Convention covers all four layers | The rule names Program, Epic, supervisor and worker forms explicitly |
| Name identifies the work, not only the role | `Epic #1` / `Task #6 supervisor` carry the issue; the role survives as a suffix where two sessions can share a number |
| Issue number is part of the name | With `#`, so it reads as a reference — a bare number could be anything, and a worker's PR number is not its Task's |
| Survives truncation | Distinguishing part is first; issue titles are deliberately excluded |
| Lives where session creation is described | Stated beside the app-tools table, and referenced from both dispatch steps (Epic start, supervisor dispatch) so it is reachable at the moment of creation |
| Nothing else changed | Kickoff completeness, mode and model selection untouched |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (353/500 lines); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

## Deviations

The issue asked for names that identify the work and worried about truncated titles; the requester then specified the opposite of what that framing implied — no issue titles at all, just `Epic #1` and `Task #6 supervisor`. Implemented as specified, and the reasoning is recorded in the skill so the choice is not re-litigated as an oversight.

`orchestrator.agent.md` needed no pointer: it already reads `session-orchestration` as its operating manual, and the rule sits in the section describing the tools it uses.
