### PR TITLE
Have onboarding create the program session, and keep conductors alive

### DIFF
--- a/.github/prompts/onboard-project.prompt.md
+++ b/.github/prompts/onboard-project.prompt.md
@@ -30,7 +30,7 @@ Optional context from me: ${input:notes}
    Free-plan caveats) and run `.github/scripts/setup-ruleset.sh` per my
    answer, draft the phase Epics from my goal and material (one per phase,
    siblings never nested, `blocked-by` in order, coarse, draft-marked, no
-   decomposition, `/breakdown-epic` pointer at the end of the first
+   decomposition, decomposition pointer at the end of the first
    phase's body), and give me their URLs to review while you verify.
 3. **P3:** verify candidate commands by actually running them; keep an
    evidence log (command, prerequisites, result, workarounds). Show me the
@@ -48,11 +48,13 @@ Optional context from me: ${input:notes}
    everything left undone in P0–P5 to the first phase Epic's body as a
    `## Deferred from onboarding` checklist (to the PR description when the
    Epics were skipped), and end the PR description with a `## Next steps`
-   section (merge this PR → review the Epics → `/breakdown-epic` on the
-   first phase). You are
+   section (merge this PR → review the Epics → hand off to the `Program`
+   session). You are
    not done at push: the PR must exist (if its creation is blocked, tell me
    and print the exact `gh pr create` command), and the chat message where
    you hand me the PR link must end with the numbered handoff — 1. merge
-   the evidence PR, 2. review the draft Epics (link them), 3. run
-   `/breakdown-epic` on the first phase when it looks right. Queued or failing checks
+   the evidence PR, 2. review the draft Epics (link them), 3. tell the
+   `Program` session to start once the PR is merged. Create that session as
+   your last act, handing it the Epic numbers and which phase is first;
+   never decompose here yourself. Queued or failing checks
    don't waive the handoff: report problems above it, never instead of it.

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -233,6 +233,16 @@ PR description instead.
 Chat is not a carrier: a deferred item that exists only in the final
 message evaporates with the session.
 
+**Start the program session** as onboarding's last act, once the evidence
+PR exists and the Epics are drafted: create a session named `Program`
+(`session-orchestration` §Program session protocol) and hand it the Epic
+numbers and which phase is first. It waits for the evidence PR to merge
+before starting the first Epic's session — a phase run against a half-tuned
+repository verifies nothing. Onboarding does not decompose, and does not
+become the program session itself: its context is spent, and conducting is
+a different job. When the Epics were skipped, create no program session and
+say so — there is nothing to conduct until an Epic exists.
+
 P6 is not complete when the branch is pushed — it is complete when the
 **evidence PR exists**. If PR creation is blocked (approval gate, missing
 permission), say so explicitly and print the exact `gh pr create` command
@@ -245,11 +255,9 @@ report them *above* the block, never instead of it.
 1. Review and merge the evidence PR (the license merge).
 2. Review and edit the P2-close draft Epics — link them here, first phase
    first (or say they were skipped and point at the Epic form).
-3. When the first phase's Epic looks right, decompose it with the
-   `plan-management` skill — decomposition
-   into Task issues starts only on your approval, one phase
-   at a time; each ready Task then runs with the `session-orchestration`
-   skill.
+3. Once the evidence PR is merged, tell the `Program` session to start —
+   it decomposes the first phase's Epic on your approval, one phase at a
+   time, and starts each later Epic's session as its turn comes.
 
 The same three moves ride durable carriers: the evidence PR description
 **ends with a `## Next steps` section**, and the first phase Epic's body

--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -191,9 +191,11 @@ You are the WORKER session for Task issue #<n> in <owner>/<repo>.
 
 ## Program session protocol
 
-One program session per project, started when the phase Epics first exist
-(onboarding drafts them) and kept for the life of the plan. It conducts
-conductors: it never decomposes, dispatches Tasks, or edits code itself.
+One program session per project, created by onboarding as its closing move
+(`project-onboarding` P6) once the phase Epics exist, and kept for the life
+of the plan. It conducts conductors: it never decomposes, dispatches Tasks,
+or edits code itself. Its first move waits for the onboarding evidence PR to
+merge — a phase started against a half-tuned repository verifies nothing.
 
 1. **Start an Epic's session when that phase's turn comes** — when its
    `blocked-by` Epics are closed, or the frontier has run dry. Hand it the
@@ -259,8 +261,11 @@ conductors: it never decomposes, dispatches Tasks, or edits code itself.
    (`plan-management` §Replanning) and post the rationale on the Epic.
 7. When the Epic's phase is done — its Tasks closed, their PRs merged, the
    Epic's own state line current — tell the program session so the next
-   phase gets a session. Do not start that session yourself: the program
-   session keeps Epic sessions siblings (see Program session protocol). If
+   phase gets a session, then stop. Do not start that session yourself and
+   do not carry on as it: the program session keeps Epic sessions siblings
+   (see Program session protocol), and a session that continues into the
+   next phase makes the tree a single thread again. Stay open until the
+   Epic closes — rework and late questions come back here. If
    no program session is running, say so in the Epic's closing comment and
    name the next Epic, so a human or a fresh program session can pick it up.
 
@@ -304,6 +309,15 @@ stay alive through review (rework returns to the same worker), so teardown
 runs after the merge, not at closeout: the requester messages the
 supervisor to tear down → the supervisor archives its worker(s) and
 acknowledges → only then does the requester archive the supervisor.
+
+**Conducting sessions are not torn down with them.** Teardown covers the
+executing layers only: workers and Task supervisors, which carry the
+heaviest context and whose record already lives on GitHub. An **Epic
+session lives until its Epic closes**; the **program session lives as long
+as the plan**. Keeping them is what makes the tree readable — `Epic #1` and
+`Epic #2` side by side — and guarantees a live session owns starting the
+next phase. Archiving them instead leaves the plan with no conductor, and
+the next phase gets absorbed into whatever session is still open.
 
 ## Resume protocol (crash-only)
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,23 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Onboarding now creates the program session and hands off to it, and
+  conducting sessions are no longer torn down. The program layer had no
+  creator — its protocol said it starts "when the phase Epics first exist"
+  while onboarding never mentioned it — and no rule said how long an Epic or
+  program session lives, so the leaf-first teardown guidance read as
+  applying all the way up. Together those produced the observed behaviour:
+  the first session became the Epic session, and when that Epic finished the
+  same session carried on as the next one, phase after phase in a single
+  thread. Onboarding now ends by creating a `Program` session and handing it
+  the Epics; that session waits for the evidence PR to merge before starting
+  the first Epic's session, since a phase run against a half-tuned
+  repository verifies nothing. Teardown is stated per layer: workers and
+  Task supervisors are archived as before, an Epic session lives until its
+  Epic closes, and the program session lives as long as the plan — which is
+  what keeps `Epic #1` and `Epic #2` visible side by side and guarantees a
+  live session owns starting the next phase (refs #39).
+
 - Sessions now have a naming convention: `Program`, `Epic #1`, `Task #6
   supervisor`, `PR #12 worker`. Nothing said how to name a session, so agents
   labelled them by role — `Task 6 supervisor` — and a sidebar of open


### PR DESCRIPTION
Closes #39

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/39#issuecomment-5275110937

## What

An adopter watching the session tree saw the first session become the Epic session, and then continue as the *next* Epic's session when that phase finished — one thread, reused phase after phase, instead of the siblings the program layer was added to produce.

Two gaps caused it, and neither alone explains it:

1. The program session had no creator. Its protocol said it starts "when the phase Epics first exist (onboarding drafts them)"; `project-onboarding` never mentioned a program session.
2. No rule stated how long an Epic or program session lives, so the leaf-first teardown guidance read as applying to every layer. With no conductor left and a phase just finished, continuing in place was the only move available.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Onboarding creates the program session | P6, as its closing act, once the evidence PR exists and the Epics are drafted |
| Named per convention, given what it needs | Named `Program`; handed the Epic numbers and which phase is first |
| Handoff no longer implies decomposing here | Step 3 now reads "tell the `Program` session to start"; onboarding is told plainly not to decompose and not to become the program session — its context is spent and conducting is a different job |
| Relationship with the evidence PR explicit | The program session waits for the merge before starting the first Epic's session: "a phase run against a half-tuned repository verifies nothing" |
| Skipped-Epics case handled | "create no program session and say so — there is nothing to conduct until an Epic exists" |
| One creator, no ambiguity | `session-orchestration` says "created by onboarding as its closing move"; `project-onboarding` says how. Neither implies the other does it |
| Lifetimes stated per layer | Workers and Task supervisors archived as today; Epic session lives until its Epic closes; program session lives as long as the plan |
| A finished Epic session does not continue | Parent protocol step 7: report up, then stop — "a session that continues into the next phase makes the tree a single thread again". It stays open until the Epic closes, since rework returns there |
| Leaf-first teardown still holds | Unchanged for the layers it covers; the addition scopes it rather than contradicting it |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (onboarding 294/500, session-orchestration 367/500); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

## Deviations

`onboard-project.prompt.md` still carried two `/breakdown-epic` references that #35 had missed — it was outside that task's ownership. Fixed here, since this change rewrites the same closing steps and leaving them would have had the prompt contradict the skill it summarizes.
