### PR TITLE
Tie worker dispatches to a session and a branch

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -14,7 +14,9 @@ two layers, and the session you are in decides which: as a **program
 session** you conduct the whole Epic set — starting each Epic's session when
 its phase comes up, watching across phases, replanning when the outline
 diverges (`session-orchestration` §Program session protocol). As an **Epic's
-parent session** you run the delivery loop below for that one Epic. Either
+parent session** you run the delivery loop below for that one Epic. It is not
+the role for supervising a single Task: that runs on the default agent with
+the session-orchestration skill (`task-routing`). Either
 way, if you find yourself editing
 application source code, stop — that work belongs in a child Task session.
 Infra/cloud/deploy work (provisioning, secrets, deploy unblocking, smoke

--- a/.github/scripts/check-task-ritual.sh
+++ b/.github/scripts/check-task-ritual.sh
@@ -28,6 +28,14 @@
 #   - a worker-dispatch comment starts with "Dispatching worker"; a release
 #     comment starts with "Releasing worker" (first-line regexes, exactly
 #     like the claim);
+#   - a dispatch's first line names the worker session and its branch. The
+#     branch must be the PR's head ref (managed prefixes allowed), which is
+#     what stops one task's dispatch from satisfying another's trail. The
+#     session ID is required but **not verified**: session trees are
+#     app-local and no API reachable from CI can enumerate them, so it is a
+#     durable record for humans and audits, not proof. This wall shows that
+#     a specific session and branch were claimed — the supervisor is
+#     responsible for having actually raised the session before writing it;
 #   - any dispatch comment selects the two-tier path: the earliest dispatch
 #     must not predate the earliest plan and must not postdate the PR's
 #     first commit (committer date, ties pass), every dispatch after the
@@ -185,7 +193,7 @@ markers=$(api "repos/{owner}/{repo}/issues/${issue}/comments" --paginate --jq '
   .[] |
   (if (.body | test("^(Starting|Resuming) in session")) then [ "CLAIM", .created_at, .updated_at ] | @tsv else empty end),
   (if ((.body | test("(^|\\n)## Plan\\b")) or (.body | startswith("Plan:"))) then [ "PLAN", .created_at, .updated_at ] | @tsv else empty end),
-  (if (.body | test("^Dispatching worker")) then [ "DISPATCH", .created_at, .updated_at ] | @tsv else empty end),
+  (if (.body | test("^Dispatching worker")) then [ "DISPATCH", .created_at, .updated_at, (.body | split("\n")[0]) ] | @tsv else empty end),
   (if (.body | test("^Releasing worker")) then [ "RELEASE", .created_at, .updated_at ] | @tsv else empty end),
   (if (((.body | test("(^|\\n)## Plan\\b")) or (.body | startswith("Plan:"))) and (.body | ascii_downcase | contains("no worker will be spawned"))) then [ "EXEMPT", .created_at, .updated_at ] | @tsv else empty end)
 ')
@@ -255,6 +263,40 @@ if [[ "$markers" == *DISPATCH* ]]; then
   earliest_dispatch=$(printf '%s\n' "$markers" | awk -F '\t' '$1 == "DISPATCH" { print $2 }' | sort | head -n1)
   mode_desc="two-tier (dispatch ${earliest_dispatch})"
 
+  # Worker identity. The dispatch comment names the session it raised and the
+  # branch that session works on. The branch is checkable — it must be the
+  # PR's head ref, so a dispatch written for one task cannot satisfy
+  # another's trail. The session ID is not: session trees are app-local and
+  # no API here can enumerate them, so it is required as a durable record for
+  # humans and audits, never treated as proof. What this wall can show is
+  # that the supervisor claimed a specific session and a matching branch.
+  head_ref=$(api "repos/{owner}/{repo}/pulls/${PR}" --jq '.head.ref')
+  while IFS=$'\t' read -r _kind _created _updated first_line; do
+    [[ -n "$first_line" ]] || continue
+    if ! printf '%s\n' "$first_line" | grep -qE 'session[[:space:]]+[0-9a-fA-F-]{8,}'; then
+      echo "FAIL: issue #${issue} has a worker-dispatch comment that names no session:"
+      echo "        ${first_line}"
+      echo "      Create the worker session first, then record it — 'Dispatching worker: PR #<n> worker (session <id>), branch <branch>' (session-orchestration skill)."
+      ok=false
+      continue
+    fi
+    dispatch_branch=$(printf '%s\n' "$first_line" | sed -n 's/.*branch[[:space:]]\{1,\}\([^ ,)]\{1,\}\).*/\1/p')
+    if [[ -z "$dispatch_branch" ]]; then
+      echo "FAIL: issue #${issue} has a worker-dispatch comment that names no branch:"
+      echo "        ${first_line}"
+      echo "      Record the worker's branch so the dispatch can be tied to this PR (session-orchestration skill)."
+      ok=false
+    elif [[ -n "$head_ref" && "$dispatch_branch" != "$head_ref" && "$head_ref" != *"$dispatch_branch" ]]; then
+      # Managed surfaces prefix the branch they generate (AGENTS.md §4), so a
+      # head ref ending in the dispatched name is the same branch.
+      echo "FAIL: issue #${issue} dispatches branch '${dispatch_branch}', but PR #${PR} is from '${head_ref}'."
+      echo "      A dispatch names the branch its worker actually works on (session-orchestration skill)."
+      ok=false
+    fi
+  done <<EOF
+$(printf '%s\n' "$markers" | awk -F '\t' '$1 == "DISPATCH"')
+EOF
+
   # Chronology 3 — the dispatch follows the plan of record: the supervisor
   # dispatches a worker to execute an already-posted plan (ADR-0003).
   if [[ "$earliest_plan" > "$earliest_dispatch" ]]; then
@@ -301,6 +343,17 @@ if [[ "$markers" == *DISPATCH* ]]; then
   done <<< "$dispatches"
 elif [[ "$markers" == *EXEMPT* ]]; then
   mode_desc="declared small-task exemption"
+
+  # The exemption is a declaration made *before* implementing, mirroring
+  # plan-before-commit. Without this, a plan carrying the phrase posted after
+  # the work still satisfies the mode check — the exemption becomes something
+  # claimed in hindsight rather than a decision the trail records.
+  earliest_exempt=$(printf '%s\n' "$markers" | awk -F '\t' '$1 == "EXEMPT" { print $2 }' | sort | head -n1)
+  if [[ -n "$first_commit" && "$earliest_exempt" > "$first_commit" ]]; then
+    echo "FAIL: PR #${PR}'s first commit (${first_commit}, committer date) predates the small-task exemption on issue #${issue} (${earliest_exempt})."
+    echo "      Declare the exemption in the plan comment before implementing (AGENTS.md §4; session-orchestration skill)."
+    ok=false
+  fi
 else
   echo "FAIL: issue #${issue} declares no execution mode: no worker-dispatch comment ('Dispatching worker …' first line) and no plan comment containing 'no worker will be spawned'."
   echo "      Dispatch a worker or declare the small-task exemption in the plan comment (AGENTS.md §4; session-orchestration skill)."

--- a/.github/scripts/tests/test-ritual-dispatch.sh
+++ b/.github/scripts/tests/test-ritual-dispatch.sh
@@ -23,7 +23,7 @@ WORK=$(mktemp -d "${TMPDIR:-/tmp}/guardtest.XXXXXX")
 trap 'rm -rf "$WORK"' EXIT
 install_gh_shim "$WORK"
 
-PR_JSON='{"user":{"login":"mochan-tk","type":"User"},"body":"Closes #12\\n\\nPlan: https://github.com/o/r/issues/12#issuecomment-777"}'
+PR_JSON='{"user":{"login":"mochan-tk","type":"User"},"head":{"ref":"task/12-x"},"body":"Closes #12\\n\\nPlan: https://github.com/o/r/issues/12#issuecomment-777"}'
 ISSUE_TASK='{"labels":[{"name":"type:task"}]}'
 PLAN_COMMENT_12='{"issue_url":"https://api.github.com/repos/o/r/issues/12","body":"## Plan\\n\\n1. Steps."}'
 
@@ -44,7 +44,7 @@ exempt_plan_sentence_at() {
   printf '{"body":"## Plan\\n\\n1. Steps.\\n\\nNo worker will be spawned.","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
 }
 dispatch_at() {
-  printf '{"body":"Dispatching worker w1 on branch task/12-x.","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
+  printf '{"body":"Dispatching worker: PR #99 worker (session 6af9582d-42d1-425d-82c8-f9ec651225a8), branch task/12-x","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
 }
 release_at() {
   printf '{"body":"Releasing worker w1 (context exhausted); successor w2 follows.","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
@@ -135,5 +135,50 @@ new_case "$PR_JSON" "[$(claim_at 2026-01-01T09:00:00Z), $(dispatch_at 2026-01-01
   "$(commits_at 2026-01-01T10:00:00Z)"
 GH_FIXTURES="$CASE" expect_rc_grep 1 'dispatch .* predates earliest plan' \
   "dispatch overrides declared exemption" bash "$GUARD" 12
+
+# --- a dispatch naming no session fails -----------------------------------------
+# The point of the two-tier split is that a worker session really exists. A
+# dispatch comment that names none records a split that may not have happened.
+dispatch_no_session_at() {
+  printf '{"body":"Dispatching worker w1 on branch task/12-x.","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
+}
+new_case "$PR_JSON" "[$(claim_at 2026-01-01T09:00:00Z), $(plan_at 2026-01-01T09:05:00Z), $(dispatch_no_session_at 2026-01-01T09:10:00Z)]" \
+  "$(commits_at 2026-01-01T10:00:00Z)"
+GH_FIXTURES="$CASE" expect_rc_grep 1 'names no session' \
+  "dispatch without a session identifier fails" bash "$GUARD" 12
+
+# --- a dispatch naming another task's branch fails ------------------------------
+# Without this, one task's dispatch comment satisfies another's trail: the
+# first line matched, and nothing tied it to this PR.
+dispatch_wrong_branch_at() {
+  printf '{"body":"Dispatching worker: PR #99 worker (session 6af9582d-42d1-425d-82c8-f9ec651225a8), branch task/34-other","created_at":"%s","updated_at":"%s"}' "$1" "${2:-$1}"
+}
+new_case "$PR_JSON" "[$(claim_at 2026-01-01T09:00:00Z), $(plan_at 2026-01-01T09:05:00Z), $(dispatch_wrong_branch_at 2026-01-01T09:10:00Z)]" \
+  "$(commits_at 2026-01-01T10:00:00Z)"
+GH_FIXTURES="$CASE" expect_rc_grep 1 "dispatches branch 'task/34-other'" \
+  "dispatch naming another branch fails" bash "$GUARD" 12
+
+# --- a managed-surface branch prefix still matches ------------------------------
+# Managed surfaces prefix the branch they generate (AGENTS.md §4), so a head
+# ref ending in the dispatched name is the same branch.
+PR_PREFIXED='{"user":{"login":"mochan-tk","type":"User"},"head":{"ref":"copilot/task/12-x"},"body":"Closes #12\\n\\nPlan: https://github.com/o/r/issues/12#issuecomment-777"}'
+new_case "$PR_PREFIXED" "[$(claim_at 2026-01-01T09:00:00Z), $(plan_at 2026-01-01T09:05:00Z), $(dispatch_at 2026-01-01T09:10:00Z)]" \
+  "$(commits_at 2026-01-01T10:00:00Z)"
+GH_FIXTURES="$CASE" expect_rc_grep 0 'two-tier' \
+  "managed-prefix head ref matches the dispatched branch" bash "$GUARD" 12
+
+# --- a retroactive exemption fails ----------------------------------------------
+# The exemption is a decision recorded before implementing, mirroring
+# plan-before-commit; claimed afterwards it is hindsight, not a trail.
+new_case "$PR_JSON" "[$(claim_at 2026-01-01T09:00:00Z), $(exempt_plan_at 2026-01-01T11:00:00Z)]" \
+  "$(commits_at 2026-01-01T10:00:00Z)"
+GH_FIXTURES="$CASE" expect_rc_grep 1 'predates the small-task exemption' \
+  "exemption declared after the first commit fails" bash "$GUARD" 12
+
+# --- an exemption declared before the commit still passes -----------------------
+new_case "$PR_JSON" "[$(claim_at 2026-01-01T09:00:00Z), $(exempt_plan_at 2026-01-01T09:05:00Z)]" \
+  "$(commits_at 2026-01-01T10:00:00Z)"
+GH_FIXTURES="$CASE" expect_rc_grep 0 'exemption' \
+  "exemption declared before the first commit passes" bash "$GUARD" 12
 
 t_summary

--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -29,15 +29,33 @@ implement directly (small-task exemption), declared in the plan comment.
 
 **Who posts what:** claim, plan, worker-dispatch, and outcome comments on
 the Task issue belong to the **supervisor**; the PR is opened and iterated
-by the **worker**. Before a worker starts, the supervisor posts a
-worker-dispatch comment (worker branch, target PR, scope); a replacement
+by the **worker**. Before a worker starts, the supervisor **creates the
+worker session, confirms it exists, and only then** posts a worker-dispatch
+comment naming it — session name, session ID, and branch, plus the target PR
+and scope. No verified worker, no implementation: a dispatch comment for a
+session that was never created records a split that did not happen, which is
+the one thing this trail exists to show (ADR-0003). A supervisor that cannot
+raise a worker either declares the small-task exemption in its plan comment
+and implements directly, or escalates — it does not write the comment
+anyway. A replacement
 worker is preceded by a comment releasing the old worker and naming its
 successor.
 **Machine-checked format:** the worker-dispatch comment's *first line* must
 match the regex `^Dispatching worker`, and the release comment's *first
 line* must match `^Releasing worker` — no leading blank line, greeting, or
 Markdown heading before either — as enforced by
-`.github/scripts/check-task-ritual.sh`. The same wall requires every task to
+`.github/scripts/check-task-ritual.sh`. That first line also carries the
+worker's identity, in this shape:
+
+```
+Dispatching worker: PR #12 worker (session 6af9582d-42d1-425d-82c8-f9ec651225a8), branch task/12-fix-esp32
+```
+
+The branch is compared against the PR's head ref, so a dispatch written for
+one task cannot satisfy another's trail. The session ID is the evidence that
+a session was really raised; CI cannot confirm it, because session trees are
+app-local, so it is recorded for humans and later audits rather than
+machine-verified. The same wall requires every task to
 declare its execution mode (ADR-0003): either a dispatch trail (earliest
 dispatch after the earliest plan and before the PR's first commit, a release
 between successive dispatches, dispatch and release comments unedited) or a

--- a/.github/skills/task-routing/SKILL.md
+++ b/.github/skills/task-routing/SKILL.md
@@ -17,6 +17,12 @@ task's supervisor lives in an app session while its worker is the cloud
 coding agent). When a supervisor implements directly under the declared
 small-task exemption, the label routes that single session.
 
+**A Task supervisor runs on the default agent** with
+`.github/skills/session-orchestration/SKILL.md` as its manual — the ritual is
+fully described there, so no separate role definition exists. Do not pick
+`orchestrator` for it: that role conducts the program and Epic layers, and
+its loop is written for a different job.
+
 ## Routing inputs
 
 Score the task on five axes before choosing:

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,27 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Worker dispatches are now tied to a session and a branch, and the
+  small-task exemption must be declared before implementing. A dispatch
+  comment carried branch, PR and scope in prose, so nothing distinguished a
+  real dispatch from a supervisor that wrote the comment and implemented the
+  work itself — the split ADR-0003 exists to produce could not be shown. The
+  comment's first line now names the worker session, its ID and its branch,
+  and the wall requires the branch to be the PR's head ref (managed prefixes
+  allowed), which also stops one task's dispatch from satisfying another's
+  trail. What the wall cannot do is stated in its header rather than implied:
+  session trees are app-local, so the ID is a durable record for humans and
+  audits, never proof — the supervisor is responsible for raising the session
+  before writing the comment, and for not writing it at all when it cannot.
+  The exemption gains the chronology its dispatch counterpart already had:
+  declared after the first commit, it is hindsight rather than a decision the
+  trail records. Task supervision is also given its agent role — the default
+  agent with the session-orchestration skill — so `orchestrator`, which
+  conducts the program and Epic layers, is not chosen for it (refs #40, #7).
+  Release consumption from #7 is deliberately not implemented: it needs a
+  matching algorithm of its own, "ties pass" was a considered trade-off, and
+  the same-second collision it guards against has not been observed.
+
 - Onboarding now creates the program session and hands off to it, and
   conducting sessions are no longer torn down. The program layer had no
   creator — its protocol said it starts "when the phase Epics first exist"


### PR DESCRIPTION
Closes #40
Closes #7

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/40#issuecomment-5275197630

## What

Implements #40 and the adoptable half of #7 together — both rewrite the same dispatch comment, and changing its format twice would have invalidated every trail written in between.

A dispatch comment used to say "Dispatching worker w1 on branch task/12-x" in prose. Nothing in it could be checked, so a supervisor could write the comment and implement the work itself and the wall would pass it.

New first line:

```
Dispatching worker: PR #12 worker (session 6af9582d-…), branch task/12-fix-esp32
```

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Dispatch records session identity | First line carries session name, ID and branch; the guard rejects a comment naming no session (`names no session`) |
| Supervisor verifies the worker before implementing | `session-orchestration`: creates the session, confirms it, *then* posts — "No verified worker, no implementation". A supervisor that cannot raise one declares the exemption or escalates, rather than writing the comment anyway |
| Small-task exemption stays available and explicit | Unchanged as an escape hatch, and now stronger: it must be declared before the first commit |
| Guard rejects a record without session identity | Fixture `dispatch without a session identifier fails`; proven non-vacuous by the paired passing case |
| Limits stated, not implied | Script header: session trees are app-local, no API reachable from CI can enumerate them, so the ID "is a durable record for humans and audits, not proof" |
| Task supervision names its agent | `task-routing`: default agent + session-orchestration skill; `orchestrator.agent.md` now says it is not the role for supervising a single Task |
| Existing fixtures pass; new ones cover the rejections | test-ritual-dispatch 11 → 16 cases, all green; run-tests.sh 16 suites green |
| Replay against a real PR | Ran the guard against this repository's merged PR #41: `PASS … mode: declared small-task exemption`, rc=0 |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet, including the deferral |

### From #7

- **Dispatch-body binding** — adopted. The branch must be the PR's head ref; managed prefixes match (fixture: `copilot/task/12-x` satisfies a dispatch for `task/12-x`).
- **Exemption chronology** — adopted. Earliest exempting plan comment must precede the first commit.
- **Release consumption** (greedy one-shot matching) — **not implemented, deliberately**. It needs a matching algorithm and fixtures of its own; "equal stamps prove nothing, so ties pass" was a considered trade-off; and the same-second collision it guards against has never been observed. #7's own acceptance criteria allow a recorded skip, which this is.

## Deviations

The existing dispatch fixture used the old prose form, so it had to be rewritten rather than merely extended — the same migration adopters face. Historical trails in this repository are unaffected in practice because the wall judges open PRs, which the replay above confirms.

One thing this change caught about itself: my own plan comment on #40 omitted the execution-mode declaration. Under the new chronology check that would fail once a commit existed, so I posted the declaration **before committing** rather than after — the behaviour the check exists to enforce, exercised on the change that adds it.
