### PR TITLE
Hold conductors to their role, and state what enforces it

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -5,7 +5,18 @@ description: Conductor session, at either layer — program (starts each Epic's 
 # (docs.github.com/en/copilot/reference/custom-agents-configuration):
 # no `edit` — the orchestrator conducts and verifies, it never edits files;
 # `agent` lets it invoke other custom agents (planner, reviewer) as
-# subagents; `github/*` is the GitHub MCP read-only toolset.
+# subagents — note a subagent shares this workspace and is never a
+# substitute for a session (session-orchestration, "A sub-agent is not a
+# session"); `github/*` is the GitHub MCP read-only toolset, present only
+# when the adopter configures that server.
+#
+# `execute` is required and is also the hole in the fence. Every step below
+# runs on it: frontier.sh, `gh issue view` / `gh pr view` / `gh pr checks`
+# for verification, and the writes this role does own — labels, Epic
+# comments, closing issues, merging. A shell can equally check out a branch
+# and write files, so withholding `edit` narrows the path without closing
+# it. The boundary ends here and discipline continues: a conductor that
+# finds itself implementing has already crossed it (AGENTS.md §4).
 tools: ["read", "search", "execute", "agent", "github/*"]
 ---
 

--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -24,8 +24,39 @@ One Task issue per supervisor session — never batch several issues into one
 session (reports become unattributable) and never split one issue across
 supervisors without replanning first. A PR has exactly one active worker at
 a time; use a separate worktree per concurrent worker so parallel sessions
-cannot write to the same checkout. For trivial tasks the supervisor may
-implement directly (small-task exemption), declared in the plan comment.
+cannot write to the same checkout. For trivial tasks **a Task supervisor**
+may implement directly (small-task exemption), declared in its plan comment;
+conductors have no such exemption — see Role boundaries.
+
+**A sub-agent is not a session.** The `agent` tool starts a helper *inside the
+caller's workspace*: same checkout, same branch, same write access, gone when
+the turn ends. Only `create_session` yields the isolated workspace and branch
+this model depends on. Calling a sub-agent "the Epic session" satisfies the
+word and defeats the isolation — the work lands in the conductor's own
+checkout, which is exactly what the layering exists to prevent. So: dispatch
+an Epic or a Task by creating a session and **confirming it exists** before
+the work proceeds; if it cannot be created, say so and stop rather than
+continuing in place. Sub-agents remain fine for what they are — bounded
+read-only research inside one turn.
+
+**Role boundaries.** A session's role is fixed when it is created; it is not
+something a session reasons its way out of mid-run. A conductor (program or
+Epic) that finds itself about to edit application files, check out a Task
+branch, or commit has met the boundary, whatever the justification: file or
+locate the Task issue, dispatch it, and verify — or escalate (§6). "It is
+small" is not a route around this; the small-task exemption belongs to Task
+supervisors, whose job is that one Task, and it does not extend to a
+conductor deciding to do the work itself.
+
+**What enforces this, and what does not.** The `orchestrator` role withholds
+`edit`, which is a real runtime grant. It keeps `execute`, because every
+conducting step runs on it — the frontier script, `gh` reads for
+verification, `gh` writes for labels, comments and merges — and a shell can
+also write files, so the grant narrows the path without closing it. Nothing
+here can pin a role to a session, deny writes per session, or hand a
+conductor a read-only workspace: those are runtime features this scaffold
+does not control. Treat the rules above as rules, not as a fence — and when
+a conductor crosses them anyway, that is a retro, not a footnote.
 
 **Who posts what:** claim, plan, worker-dispatch, and outcome comments on
 the Task issue belong to the **supervisor**; the PR is opened and iterated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,9 @@ dispatch, verification, outcome — and edits no application code; before a
 worker starts, it posts a worker-dispatch comment on the Task issue, and a
 replacement is preceded by a release-and-successor comment. Workers execute
 the approved plan in autopilot with no plan gate of their own, escalating
-per §6 when the plan breaks. For trivial tasks the supervisor may implement
-directly, declared in the plan comment ("no worker will be spawned").
+per §6 when the plan breaks. For trivial tasks the supervisor — and only a
+Task supervisor, never a conductor — may implement directly, declared in
+the plan comment ("no worker will be spawned").
 Stacked PRs = N sequential workers (only the final layer carries
 `Closes #<n>`, earlier layers `Refs #<n>`; activation gated by #89).
 Branch: `task/<issue-number>-<short-slug>`; a managed surface's generated

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,23 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Conductor sessions are held to their role, and the limits of that are
+  stated. An adopter reported a program conductor implementing Task work in
+  its own workspace — twice, the second time after being corrected — by
+  calling a sub-agent "the Epic session" and invoking the small-task
+  exemption. The documents already forbade it; the gap was that nothing said
+  a sub-agent runs in the *caller's* workspace and is never a substitute for
+  a session, that a role is fixed at creation rather than reasoned about
+  mid-run, or that the exemption belongs to Task supervisors alone. All three
+  are now stated, and dispatch must confirm a real session exists before work
+  proceeds. The `orchestrator` role's tool grant is explained rather than
+  left to look like a fence: it withholds `edit`, but keeps `execute` because
+  every conducting step runs on it, and a shell writes files too — so the
+  grant narrows the path without closing it. Immutable role metadata,
+  per-session write denial and read-only workspaces are runtime features this
+  scaffold does not control, and the skill says so instead of implying
+  otherwise (refs #43).
+
 - Worker dispatches are now tied to a session and a branch, and the
   small-task exemption must be declared before implementing. A dispatch
   comment carried branch, PR and scope in prose, so nothing distinguished a


### PR DESCRIPTION
Closes #43

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/43#issuecomment-5277140989

## What

An adopter reported a program conductor implementing Task work in its own writable workspace, and doing it again after correction. Their diagnosis — "an execution-boundary problem rather than missing documentation" — held up against the files.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Conductor cannot write app files / drive git — or the need is named and the risk stated | `execute` cannot be removed: `frontier.sh` (verified free of write commands), `gh` reads for verification and `gh` writes for labels/comments/merges all run on it, and `github/*` cannot replace them because `.vscode/mcp.json` ships no GitHub MCP server. The agent file now says the shell is also a write path, so the grant narrows without closing |
| `execute` removed or justified | Justified in `orchestrator.agent.md`, with the residual risk named |
| Sub-agent distinguished from session | "A sub-agent is not a session" — same workspace, same branch, gone at turn end; only `create_session` isolates. Calling one "the Epic session" is named as the failure it was |
| Dispatch requires confirming a real session | "dispatch an Epic or a Task by creating a session and **confirming it exists** before the work proceeds; if it cannot be created, say so and stop rather than continuing in place" — mirrors the worker rule from #42 |
| Exemption scoped to Task supervisors | `AGENTS.md` §4: "the supervisor — and only a Task supervisor, never a conductor"; the skill repeats the scope where the exemption is described |
| Self-reclassification addressed | "A session's role is fixed when it is created; it is not something a session reasons its way out of mid-run", with what to do instead: file/locate the Task, dispatch, verify, or escalate |
| Unenforceable parts recorded | "Nothing here can pin a role to a session, deny writes per session, or hand a conductor a read-only workspace: those are runtime features this scaffold does not control" |
| CHANGELOG | SCAFFOLD-CHANGELOG.md Unreleased, top bullet |
| Verification wall | check-copilot-surface OK (AGENTS.md 117/200, skill 416/500); run-tests.sh 16 suites green; check-md-links OK; check-escalation-wording OK; check-changelog-refs OK |

### The reporter's reproduction outline, walked against the new text

| Step | What now answers it |
|---|---|
| 4. Does the conductor use a same-workspace sub-agent instead of a session? | "A sub-agent is not a session", plus confirm-before-proceed at dispatch |
| 6a. Can it self-reclassify? | Role is fixed at creation; a conductor about to implement has met the boundary |
| 6b. Can it invoke a small-task exemption? | Exemption is a Task supervisor's, in both `AGENTS.md` and the skill |

## Deviations

The issue suggested recording the unenforceable asks in `.github/docs/adopter-feedback.md`. That file specifies the feedback *mechanism* — what is sent, what is never collected — so upstream wishes would sit oddly there, and `retro-log.md` is a ledger of changes actually made. The limits are stated in the skill instead, where the reader meets them at the moment they matter. The four runtime asks stay on this issue for anyone raising them with the app.

Four of the report's seven suggestions are not implementable here at all — immutable role metadata, per-session write denial, API-level sub-agent distinction, read-only workspaces. Writing prose that gestures at them would repeat the exact mistake being reported, so this PR implements the three that change behaviour and says plainly that the rest is not a fence.
