### PR TITLE
Let the orchestrator run the protocol it exists to run

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -17,7 +17,19 @@ description: Conductor session, at either layer — program (starts each Epic's 
 # and write files, so withholding `edit` narrows the path without closing
 # it. The boundary ends here and discipline continues: a conductor that
 # finds itself implementing has already crossed it (AGENTS.md §4).
-tools: ["read", "search", "execute", "agent", "github/*"]
+#
+# The session tools are named because `tools` is a strict allowlist: a list
+# grants only what it lists, so conducting without them is not conducting.
+# They are product-specific, which is fine — unrecognized names are ignored
+# by design, so this profile stays portable to surfaces that have no
+# sessions. Do not "tidy them away": without them this agent cannot
+# dispatch, steer, approve a plan or tear down, which is the whole of its
+# job (#47). `check-agent-tools.sh` keeps this list and the protocol table
+# in `session-orchestration` from drifting apart again.
+tools: ["read", "search", "execute", "agent", "github/*",
+        "create_session", "open_issue_session", "send_session_message",
+        "respond_to_session_plan", "get_session", "list_sessions_and_chats",
+        "archive_session"]
 ---
 
 You are the orchestrator. You conduct; you do not implement. The role runs at

--- a/.github/scripts/check-agent-tools.sh
+++ b/.github/scripts/check-agent-tools.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# check-agent-tools.sh — fail when the orchestrator's tool allowlist and the
+# protocol it is supposed to run have drifted apart.
+#
+# Why: a custom agent's `tools` property is a strict allowlist. Omit it (or
+# write `["*"]`) and the agent gets everything; write a list and it gets
+# only what the list names. The scaffold shipped `orchestrator` with
+# ["read", "search", "execute", "agent", "github/*"] and a skill telling it
+# to create sessions, message children, approve their plans and archive
+# them — none of which it could do. The defect survived from the first
+# commit because nothing compared the two files (#47).
+#
+# Unrecognized tool names are ignored by the runtime, which is what makes
+# naming app tools in a portable profile safe — and also what makes this
+# failure silent: a missing name looks exactly like a name that does not
+# apply here. Silence is why this guard exists.
+#
+# The rule this enforces, in both directions:
+#   1. Every app tool the skill's protocol table names must appear in the
+#      orchestrator's allowlist. Add a protocol step, grant its tool.
+#   2. The allowlist must stay an allowlist, and `edit` must stay out of it
+#      (AGENTS.md §4, #43) — including its aliases and the `*` wildcard,
+#      so the role cannot be unrestricted by a well-meaning cleanup.
+#
+# Usage: check-agent-tools.sh [skill_file] [agent_file]
+# Output: brief OK summary and exit 0 when the two agree; the specific
+# mismatch and exit 1 otherwise.
+# Dependencies: bash 3.2+, awk, grep, sed, tr only.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="${1:-$ROOT/.github/skills/session-orchestration/SKILL.md}"
+AGENT="${2:-$ROOT/.github/agents/orchestrator.agent.md}"
+
+for f in "$SKILL" "$AGENT"; do
+  [ -r "$f" ] || { echo "check-agent-tools: ERROR — cannot read $f" >&2; exit 2; }
+done
+
+# Rows of the protocol table whose first cell names an argument rather than a
+# tool. `notify_on_idle` is a parameter of create_session; granting it is not
+# a thing the runtime can do.
+NOT_TOOLS="notify_on_idle"
+
+# Aliases that grant editing, per GitHub's custom-agent tool-alias table.
+# Compared case-insensitively, as the runtime does.
+EDIT_ALIASES="edit multiedit write notebookedit"
+
+protocol_tools=$(
+  awk '
+    /App tools that instantiate the protocol/ { intable = 1; next }
+    intable && /^\|/ {
+      cell = $0
+      sub(/^\|[ \t]*/, "", cell)
+      sub(/[ \t]*\|.*$/, "", cell)
+      if (match(cell, /`[A-Za-z_][A-Za-z0-9_]*`/)) {
+        print substr(cell, RSTART + 1, RLENGTH - 2)
+        seen = 1
+      }
+      next
+    }
+    intable && seen && !/^\|/ { intable = 0 }
+  ' "$SKILL"
+)
+
+if [ -z "$protocol_tools" ]; then
+  echo "check-agent-tools: FAIL — no protocol tool table found in $SKILL" >&2
+  echo "  Expected a table under 'App tools that instantiate the protocol'." >&2
+  echo "  If that section was renamed, this guard must be renamed with it." >&2
+  exit 1
+fi
+
+tools_block=$(awk '/^tools:/ { found = 1 } found { print; if (/\]/) exit }' "$AGENT")
+if [ -z "$tools_block" ]; then
+  echo "check-agent-tools: FAIL — $AGENT declares no 'tools' property." >&2
+  echo "  An absent allowlist grants every tool, 'edit' included, which is" >&2
+  echo "  the grant AGENTS.md §4 relies on withholding." >&2
+  exit 1
+fi
+
+# Both documented forms: a YAML flow array (possibly wrapped over several
+# lines) and a bare comma-separated string.
+if printf '%s' "$tools_block" | grep -q '\['; then
+  allowed=$(printf '%s' "$tools_block" \
+    | tr "'" '"' \
+    | grep -o '"[^"]*"' \
+    | tr -d '"' \
+    | tr '\n' ' ')
+else
+  allowed=$(printf '%s' "$tools_block" \
+    | sed 's/^tools:[[:space:]]*//' \
+    | tr ',' '\n' \
+    | tr -d '"'"'" \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | tr '\n' ' ')
+fi
+
+errors=0
+report() { echo "check-agent-tools: FAIL — $1" >&2; errors=$((errors + 1)); }
+
+# Word-splitting the tool lists must not glob: an allowlist of ["*"] would
+# otherwise expand to the working directory's filenames and vanish.
+set -f
+
+# `*` grants everything, so membership is moot and the wildcard is itself
+# the violation: it hands back the one grant this role withholds.
+case " $allowed " in
+  *" * "*)
+    report "the orchestrator's allowlist is '*', which grants 'edit'."
+    echo "  The role conducts and verifies; it does not edit files (#43)." >&2
+    exit 1
+    ;;
+esac
+
+for tool in $protocol_tools; do
+  case " $NOT_TOOLS " in *" $tool "*) continue ;; esac
+  case " $allowed " in
+    *" $tool "*) ;;
+    *)
+      report "the protocol uses '$tool' but the orchestrator cannot."
+      echo "  $SKILL names it a protocol step; $AGENT does not grant it." >&2
+      echo "  Add \"$tool\" to the tools list, or stop calling it a step." >&2
+      ;;
+  esac
+done
+
+for granted in $allowed; do
+  lower=$(printf '%s' "$granted" | tr '[:upper:]' '[:lower:]')
+  case " $EDIT_ALIASES " in
+    *" $lower "*)
+      report "the orchestrator grants '$granted', an alias of 'edit'."
+      echo "  Withholding edit is the one runtime boundary this scaffold" >&2
+      echo "  actually has (AGENTS.md §4). Conduct, do not implement." >&2
+      ;;
+  esac
+done
+
+if [ "$errors" -gt 0 ]; then
+  exit 1
+fi
+
+granted_count=$(printf '%s' "$allowed" | wc -w | tr -d ' ')
+checked_count=$(printf '%s\n' "$protocol_tools" | grep -c . | tr -d ' ')
+echo "check-agent-tools: OK — $checked_count protocol tool row(s) reconciled" \
+     "against $granted_count granted tool(s); edit withheld."

--- a/.github/scripts/check-copilot-surface.sh
+++ b/.github/scripts/check-copilot-surface.sh
@@ -11,6 +11,8 @@
 #   6. English-only:  alphabetic characters in scaffold-owned text files
 #                     (AGENTS.md, SCAFFOLD-CHANGELOG.md, .github/**) are
 #                     Latin script; app-owned files are out of scope.
+#   7. Agent tools:   delegated to check-agent-tools.sh — the orchestrator's
+#                     allowlist must still grant what the protocol uses.
 #
 # Frontmatter is parsed with PyYAML (yaml.safe_load semantics plus a
 # duplicate-key rejection); malformed YAML fails the wall with file:line.
@@ -226,3 +228,9 @@ print(
     f"(of {len(tracked_set)} tracked)."
 )
 PY
+
+# The frontmatter above is validated as YAML; whether the tools it grants
+# match the protocol the agent is told to run is a separate question, and
+# one nothing asked until an adopter's Program session could not create a
+# session (#47). Delegated so the check stays testable on its own inputs.
+bash "$ROOT/.github/scripts/check-agent-tools.sh"

--- a/.github/scripts/tests/test-agent-tools.sh
+++ b/.github/scripts/tests/test-agent-tools.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# test-agent-tools.sh — regression tests for
+# .github/scripts/check-agent-tools.sh.
+#
+# The guard exists because a custom agent's `tools` property is a strict
+# allowlist and unrecognized names are silently ignored: an orchestrator
+# missing `create_session` looks exactly like one running somewhere that
+# has no sessions. The scaffold shipped that defect from its first commit
+# (#47). Each case writes a throwaway skill/agent pair and asserts the exit
+# code and message.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+GUARD="$REPO_ROOT/.github/scripts/check-agent-tools.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/agenttools.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+write_skill() {
+  cat > "$WORK/$1" <<'EOF'
+Prose before the table that must not be scanned for `tool_names`.
+
+App tools that instantiate the protocol:
+
+| Tool | Protocol step |
+|---|---|
+| `create_session` (kickoff prompt, mode, model) | Dispatch a supervisor or worker |
+| `send_session_message` | Steering and the report hop |
+| `notify_on_idle` | Wake the parent when a child stops |
+
+Prose after the table mentioning `archive_session`, which is not a row.
+EOF
+}
+
+write_agent() {
+  printf -- '---\nname: orchestrator\ndescription: Conductor session.\ntools: %s\n---\n\nBody.\n' \
+    "$2" > "$WORK/$1"
+}
+
+# --- a synced pair passes --------------------------------------------------
+write_skill skill-ok.md
+write_agent agent-ok.md '["read", "execute", "create_session", "send_session_message"]'
+expect_rc_grep 0 "check-agent-tools: OK" \
+  "allowlist covering every protocol row passes" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-ok.md"
+
+# --- the shipped defect: a protocol tool absent from the allowlist ---------
+write_agent agent-missing.md '["read", "search", "execute", "agent", "github/*"]'
+expect_rc_grep 1 "the protocol uses 'create_session' but the orchestrator cannot" \
+  "a protocol tool missing from the allowlist fails" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-missing.md"
+
+# --- notify_on_idle is an argument, not a grantable tool ------------------
+expect_rc_grep 1 "create_session" \
+  "the argument row is not reported as a missing tool" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-missing.md"
+if bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-missing.md" 2>&1 \
+   | grep -q "notify_on_idle"; then
+  t_fail "notify_on_idle must not be demanded as a tool"
+else
+  t_ok "notify_on_idle is excluded as an argument"
+fi
+
+# --- edit must stay withheld, under any alias ------------------------------
+write_agent agent-edit.md '["read", "edit", "create_session", "send_session_message"]'
+expect_rc_grep 1 "an alias of 'edit'" \
+  "granting edit fails" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-edit.md"
+
+write_agent agent-write.md '["read", "Write", "create_session", "send_session_message"]'
+expect_rc_grep 1 "an alias of 'edit'" \
+  "granting an edit alias under another name fails" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-write.md"
+
+# --- an unrestricted allowlist is not a fix -------------------------------
+write_agent agent-star.md '["*"]'
+expect_rc_grep 1 "allowlist is '\*'" \
+  "the wildcard allowlist fails" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-star.md"
+
+# --- no tools property at all grants everything ---------------------------
+printf -- '---\nname: orchestrator\ndescription: Conductor session.\n---\n\nBody.\n' \
+  > "$WORK/agent-none.md"
+expect_rc_grep 1 "declares no 'tools' property" \
+  "an absent allowlist fails" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-none.md"
+
+# --- the flow array may wrap over several lines ---------------------------
+cat > "$WORK/agent-wrapped.md" <<'EOF'
+---
+name: orchestrator
+description: Conductor session.
+tools: ["read", "execute",
+        "create_session",
+        "send_session_message"]
+---
+
+Body.
+EOF
+expect_rc_grep 0 "check-agent-tools: OK" \
+  "a wrapped flow array is parsed whole" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-wrapped.md"
+
+# --- the comma-separated string form is also documented -------------------
+write_agent agent-csv.md 'read, execute, create_session, send_session_message'
+expect_rc_grep 0 "check-agent-tools: OK" \
+  "the comma-separated string form is parsed" \
+  bash "$GUARD" "$WORK/skill-ok.md" "$WORK/agent-csv.md"
+
+# --- a renamed section must not silently disable the guard ----------------
+printf 'No protocol table here.\n' > "$WORK/skill-empty.md"
+expect_rc_grep 1 "no protocol tool table found" \
+  "losing the table fails loudly instead of passing vacuously" \
+  bash "$GUARD" "$WORK/skill-empty.md" "$WORK/agent-ok.md"
+
+# --- the real files must agree --------------------------------------------
+expect_rc_grep 0 "check-agent-tools: OK" \
+  "the shipped orchestrator can run the shipped protocol" \
+  bash "$GUARD"
+
+t_summary

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,20 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The `orchestrator` agent can now run the protocol it exists to run. Its
+  `tools` allowlist granted `read`, `search`, `execute`, `agent` and
+  `github/*` — and `tools` is strict, so every app session tool was
+  withheld. Five of the six rows in session-orchestration's own protocol
+  table were unavailable to it: it could not dispatch, steer, approve a
+  `risk:high` plan, or tear a worker down. An adopter found it when a
+  `Program` session could not create an Epic session. The tools are now
+  named (product-specific names are ignored where they do not apply, which
+  is what makes a portable profile able to carry them), `edit` stays
+  withheld, and `check-agent-tools.sh` reconciles the allowlist against the
+  protocol table so the two cannot drift apart again — including rejecting
+  `edit` under any alias and the `*` wildcard. The defect dated from the
+  first commit, which is to say no Program session had ever been run on
+  this agent, here included (#47).
 - A dispatched session is now proven to have **started**, not merely to exist.
   An adopter reported a child session created with a kickoff going idle having
   run nothing: the session was there, the work never began, no error surfaced,


### PR DESCRIPTION
Closes #47

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/47#issuecomment-5279821155

## What

An adopter's `Program` session could not create an Epic session. `tools` is a strict allowlist, and `orchestrator` listed only `read`, `search`, `execute`, `agent`, `github/*` — so **every** app session tool was withheld, not just the one they hit.

| Protocol row in `session-orchestration` | Before | After |
|---|---|---|
| `create_session` — dispatch | no | yes |
| `open_issue_session` — dispatch from the issue | no | yes |
| `respond_to_session_plan` — the `risk:high` gate | no | yes |
| `send_session_message` — steering, escalation, report hop | no | yes |
| `archive_session` — teardown | no | yes |
| `notify_on_idle` | argument of `create_session`, not grantable | — |

Also granted: `get_session` and `list_sessions_and_chats`, which the loop needs to read a child's pending plan and to reuse a session instead of duplicating it.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| The orchestrator can run its own protocol | `tools` now names the five protocol tools plus `get_session` / `list_sessions_and_chats`; `check-agent-tools.sh` reconciles the list against the table and reports `6 protocol tool row(s) reconciled against 12 granted tool(s)` |
| `edit` remains withheld | Same guard asserts it, under every documented alias (`edit`, `MultiEdit`, `Write`, `NotebookEdit`, case-insensitive) and rejects `["*"]`. Test cases: "granting edit fails", "granting an edit alias under another name fails", "the wildcard allowlist fails" |
| The agent file explains the enumeration | "They are product-specific, which is fine — unrecognized names are ignored by design, so this profile stays portable to surfaces that have no sessions. Do not 'tidy them away'" |
| A guard keeps the two in sync | `.github/scripts/check-agent-tools.sh`, invoked from `check-copilot-surface.sh` (already wired into the `copilot-surface` CI job) |
| The guard actually catches this defect | **Written before the fix and run against the broken pair — it reported all five missing tools by name.** Output is in the issue thread; re-runnable via `git stash` on the agent file |
| Test covers both directions | `test-agent-tools.sh`, 12 cases: synced pair passes; missing tool fails; argument row excluded; edit and its aliases fail; wildcard fails; absent `tools` fails; wrapped array and comma-separated forms parse; a lost table fails loudly rather than vacuously passing; the shipped pair agrees |
| `planner` / `reviewer` checked | Both list `["read", "search", "execute", "github/*"]` and neither dispatches — they work through `gh` on `execute`. Left alone |
| Verification wall | check-copilot-surface OK; run-tests.sh 17 suites green; shellcheck clean on both new files; check-md-links, check-changelog-refs, check-escalation-wording OK |

## Deviations

**No runtime capability test.** The issue asked whether CI could prove a Program session can really create a session; it cannot observe another session's tool grants. The static cross-check is the honest substitute and is described as one rather than dressed up as the thing that was asked for.

`ci.yml` is outside this task's File ownership, so the guard is invoked from `check-copilot-surface.sh` — which is owned, and already runs in CI — rather than added as a new workflow step.

## What this says about our own testing

The `tools` line dates from `Initial import`. It was never broken by a later change; it never worked. That means no `Program` session has ever been run on the `orchestrator` agent — not in the adopter's repository, and not in ours. The guard is the part that matters here: the fix is one line of YAML, and the reason the line was wrong for the whole life of the repository is that nothing compared the two files.
