### PR TITLE
Reach Git Bash on Windows instead of the WSL launcher

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,10 +6,19 @@ file as part of your PR (see the retro skill).
 
 ## First contact
 
-At the start of a session, run `bash .github/scripts/tuning-status.sh --quiet`.
-If it exits non-zero, this scaffold is **not onboarded**: your first reply
-must say so, offer to run `/onboard-project` (the project-onboarding skill),
-and wait for an explicit yes or no before taking on any other task.
+At the start of a session, run `bash .github/scripts/tuning-status.sh --quiet`
+— on Windows, `pwsh .github/scripts/run.ps1 tuning-status.sh --quiet` instead,
+because typing `bash` there reaches the WSL launcher rather than Git Bash even
+when Git for Windows is correctly installed.
+
+Read the exit code as three answers, not two. **0** means tuned. **1** means
+`CUSTOMIZE` markers remain: this scaffold is **not onboarded**, so your first
+reply must say so, offer to run `/onboard-project` (the project-onboarding
+skill), and wait for an explicit yes or no before taking on any other task.
+**Anything else** — a usage error, a missing interpreter, a script that is not
+there — means the check did not run. Say that plainly and say what you will do
+next; never report it as either answer, and never carry on as though the
+scaffold were tuned.
 
 `AGENTS.md` at the repository root defines the operating protocol
 (persistence rule, record-before-report, verify-before-done, unit of work,

--- a/.github/scripts/run.ps1
+++ b/.github/scripts/run.ps1
@@ -1,0 +1,91 @@
+# run.ps1 - Windows launcher for the scaffold's bash scripts.
+#
+# Why this exists: on Windows, typing `bash` does not reach Git Bash on a
+# correctly configured machine. The Git for Windows installer's recommended
+# PATH option adds only `...\Git\cmd` (which holds git.exe); bash.exe lives
+# in `...\Git\bin`, left off PATH on purpose to avoid DLL conflicts. What is
+# on PATH is `C:\Windows\System32\bash.exe`, the WSL launcher - which needs a
+# configured distro and sees a different filesystem than the app's worktrees.
+# So `bash .github/scripts/tuning-status.sh` reaches WSL with nothing
+# misconfigured. This launcher resolves the real interpreter instead.
+#
+# Thin shim only. It resolves bash, forwards arguments, and returns the
+# script's exit code. It parses no output, interprets no exit code, and
+# knows nothing about what any script decides - every judgement stays in the
+# one canonical .sh, so there is no second implementation to drift (#49).
+#
+# Usage (from the repository root):
+#   pwsh .github/scripts/run.ps1 tuning-status.sh --quiet
+#   pwsh .github/scripts/run.ps1 tests/run-tests.sh
+# The script name is relative to .github/scripts/; an absolute path or a
+# path to anywhere else in the repository also works.
+#
+# Prerequisite: Git for Windows (https://gitforwindows.org). The GitHub
+# Copilot app already requires Git, and this is the bash that ships with it.
+# Exit codes: whatever the invoked script returns. Failure to resolve bash,
+# or a missing script, raises a terminating error instead - "could not run"
+# must never be mistaken for a result.
+
+$ErrorActionPreference = 'Stop'
+
+function Find-GitBash {
+    # Standard Git for Windows locations first, then PATH. System32 is
+    # excluded throughout: that bash.exe is the WSL launcher.
+    $candidates = @(
+        "$env:ProgramFiles\Git\bin\bash.exe",
+        "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+        "$env:LocalAppData\Programs\Git\bin\bash.exe"
+    ) | Where-Object { $_ -match '^[A-Za-z]:\\' }
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c -PathType Leaf) { return $c }
+    }
+    # PATH second, with the WSL launcher excluded: that bash.exe is not
+    # Git Bash. Built by string concatenation rather than Join-Path, which
+    # resolves the drive and therefore only works on Windows - this line has
+    # to be evaluable anywhere so the search can be exercised in tests.
+    $systemRoot = $env:SystemRoot
+    if (-not $systemRoot) { $systemRoot = 'C:\Windows' }
+    $sys32 = $systemRoot.TrimEnd('\') + '\System32'
+    $onPath = @(Get-Command bash.exe -All -CommandType Application -ErrorAction SilentlyContinue) |
+        Where-Object { $_.Source -and -not $_.Source.StartsWith($sys32, [System.StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+    if ($onPath) { return $onPath.Source }
+    return $null
+}
+
+if ($args.Count -lt 1) {
+    throw ('Usage: run.ps1 <script.sh> [arguments]  -  for example, ' +
+        'run.ps1 tuning-status.sh --quiet')
+}
+
+$scriptArg = "$($args[0])"
+$forward = @()
+if ($args.Count -gt 1) { $forward = @($args[1..($args.Count - 1)] | ForEach-Object { "$_" }) }
+
+# Resolve relative to .github/scripts/ first, then as given, so both
+# `run.ps1 tuning-status.sh` and `run.ps1 .github/scripts/tuning-status.sh`
+# work from the repository root.
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$target = $null
+foreach ($candidate in @((Join-Path $here $scriptArg), $scriptArg)) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        $target = (Resolve-Path -LiteralPath $candidate).Path
+        break
+    }
+}
+if (-not $target) {
+    throw "Script not found: $scriptArg (looked in $here and as given)."
+}
+
+$bash = Find-GitBash
+if (-not $bash) {
+    throw ('Git for Windows is required but bash.exe was not found ' +
+        '(standard install locations and PATH were searched; the WSL ' +
+        'launcher in System32 is skipped deliberately). Install it from ' +
+        'https://gitforwindows.org and re-run. The GitHub Copilot app ' +
+        'already requires Git; this is the bash that ships with it.')
+}
+
+# Forward slashes so MSYS bash accepts the Windows path.
+& $bash ($target -replace '\\', '/') @forward
+exit $LASTEXITCODE

--- a/.github/scripts/tests/test-run-shim.sh
+++ b/.github/scripts/tests/test-run-shim.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# test-run-shim.sh — regression tests for .github/scripts/run.ps1.
+#
+# The shim exists because `bash` on Windows reaches the WSL launcher, not
+# Git Bash: the Git for Windows installer leaves `...\Git\bin` off PATH on
+# purpose, while `System32\bash.exe` is on it by default (#49).
+#
+# Two layers, because this repository's CI runs on Linux:
+#   * structural assertions, which run everywhere — they protect the two
+#     properties that make the shim correct (System32 excluded, install
+#     locations preferred) and the rule that keeps it honest (no judgement
+#     of its own);
+#   * behavioural assertions, which need a PowerShell interpreter and are
+#     reported as skipped when there is none. A skip is printed, never
+#     silently passed — an untested claim is the thing this scaffold keeps
+#     being bitten by.
+#
+# Even with pwsh present, this only proves the shim's non-Windows paths.
+# Resolving a real Git Bash can be checked on Windows and nowhere else.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+SHIM="$REPO_ROOT/.github/scripts/run.ps1"
+
+# --- structural: the shim exists and is wired to the scripts directory ----
+if [ -r "$SHIM" ]; then
+  t_ok "run.ps1 is present"
+else
+  t_fail "run.ps1 is missing — the documented Windows invocation cannot work"
+  t_summary; exit
+fi
+
+# --- structural: the WSL launcher must stay excluded ----------------------
+if grep -q 'System32' "$SHIM" && grep -qi 'StartsWith' "$SHIM"; then
+  t_ok "the search excludes System32 (the WSL launcher)"
+else
+  t_fail "the System32 exclusion is gone — bare PATH lookup finds WSL first"
+fi
+
+# --- structural: install locations are searched before PATH ---------------
+if awk '/ProgramFiles/ { pf = NR } /Get-Command bash.exe/ { gc = NR }
+        END { exit !(pf && gc && pf < gc) }' "$SHIM"; then
+  t_ok "standard install locations are searched before PATH"
+else
+  t_fail "PATH is consulted before the install locations, or one is missing"
+fi
+
+# --- structural: drive-qualified paths must not go through Join-Path ------
+# Join-Path resolves the drive, so 'C:\Windows' fails anywhere without a C:
+# drive — which is every machine this test runs on.
+if grep -q "Join-Path .*systemRoot" "$SHIM"; then
+  t_fail "SystemRoot is joined with Join-Path — unevaluable off Windows"
+else
+  t_ok "the System32 prefix is built without drive resolution"
+fi
+
+# --- structural: the shim must not decide anything ------------------------
+if grep -qE 'CUSTOMIZE|FINDINGS|-eq 0.*tuned|not onboarded' "$SHIM"; then
+  t_fail "run.ps1 interprets a script's result — judgement belongs in the .sh"
+else
+  t_ok "the shim carries no judgement of its own"
+fi
+
+# --- behavioural: needs an interpreter ------------------------------------
+PWSH=""
+for candidate in pwsh powershell /tmp/pwsh/pwsh; do
+  if command -v "$candidate" >/dev/null 2>&1; then PWSH="$candidate"; break; fi
+  if [ -x "$candidate" ]; then PWSH="$candidate"; break; fi
+done
+
+if [ -z "$PWSH" ]; then
+  echo "# skip - no PowerShell interpreter; run.ps1's behaviour was not executed."
+  echo "#        Structural assertions above still ran. Install PowerShell to"
+  echo "#        exercise the argument, resolution and missing-bash paths."
+  t_summary; exit
+fi
+
+run_shim() {
+  ( cd "$REPO_ROOT" && "$PWSH" -NoProfile -File "$SHIM" "$@" 2>&1 )
+}
+
+# The file must parse: a syntax error would ship a shim that cannot start.
+parse_out=$("$PWSH" -NoProfile -Command "
+  \$errors = \$null
+  [System.Management.Automation.Language.Parser]::ParseFile('$SHIM', [ref]\$null, [ref]\$errors) | Out-Null
+  if (\$errors) { \$errors | ForEach-Object { \$_.Message } } else { 'parse OK' }" 2>&1)
+case "$parse_out" in
+  *"parse OK"*) t_ok "run.ps1 parses" ;;
+  *) t_fail "run.ps1 has a parse error: $parse_out" ;;
+esac
+
+# No arguments is a usage error, not a silent success.
+out=$(run_shim); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'Usage: run.ps1'; then
+  t_ok "no arguments fails with usage"
+else
+  t_fail "no arguments should fail with usage (rc=$rc)"
+fi
+
+# A missing script is named, not silently skipped.
+out=$(run_shim no-such-script.sh); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'Script not found'; then
+  t_ok "a missing script fails by name"
+else
+  t_fail "a missing script should fail by name (rc=$rc)"
+fi
+
+# Off Windows there is no Git Bash, so the resolution failure must be the
+# actionable message — the same path a Windows machine without Git takes.
+out=$(run_shim tuning-status.sh --quiet); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'Git for Windows is required'; then
+  t_ok "an unresolvable bash fails with the Git for Windows message"
+else
+  t_fail "expected the Git for Windows message (rc=$rc): $(printf '%s' "$out" | head -2)"
+fi
+
+t_summary

--- a/.github/scripts/tests/test-run-shim.sh
+++ b/.github/scripts/tests/test-run-shim.sh
@@ -66,16 +66,20 @@ else
 fi
 
 # --- behavioural: needs an interpreter ------------------------------------
+# PWSH_BIN allows an interpreter that is installed but not on PATH; the
+# usual names are tried first so nothing has to be configured.
 PWSH=""
-for candidate in pwsh powershell /tmp/pwsh/pwsh; do
+for candidate in pwsh powershell "${PWSH_BIN:-}"; do
+  [ -n "$candidate" ] || continue
   if command -v "$candidate" >/dev/null 2>&1; then PWSH="$candidate"; break; fi
   if [ -x "$candidate" ]; then PWSH="$candidate"; break; fi
 done
 
 if [ -z "$PWSH" ]; then
   echo "# skip - no PowerShell interpreter; run.ps1's behaviour was not executed."
-  echo "#        Structural assertions above still ran. Install PowerShell to"
-  echo "#        exercise the argument, resolution and missing-bash paths."
+  echo "#        Structural assertions above still ran. Install PowerShell, or"
+  echo "#        set PWSH_BIN, to exercise the argument, resolution and"
+  echo "#        missing-bash paths."
   t_summary; exit
 fi
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ starts each Epic's session, which supervises its Tasks), which no other
 surface provides. Copilot CLI and IDE chat execute individual tasks
 alongside it; they are not substitutes for the app.
 
+**On Windows**, also install [Git for Windows](https://gitforwindows.org) —
+the app already requires Git, and its `bash.exe` is what runs these scripts.
+Do not type `bash` there: the installer leaves `…\Git\bin` off `PATH` by
+design, so `bash` finds the WSL launcher in `System32` instead. Run scaffold
+scripts through the launcher, which locates the real Git Bash for you:
+`pwsh .github/scripts/run.ps1 <script.sh> [arguments]`.
+
 **Supported plans:** public repositories work on any GitHub plan; private
 ones require a paid plan (the scaffold relies on features that need one),
 so `setup-sources.sh` treats private + Free as a hard stop — make the

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Windows can run the first-contact check. `bash` there reaches the WSL
+  launcher, not Git Bash — the Git for Windows installer leaves `…\Git\bin`
+  off `PATH` deliberately, while `System32\bash.exe` is on it by default, so
+  the documented command failed on a correctly configured machine. New
+  `.github/scripts/run.ps1` resolves the real Git Bash (install locations
+  first, `System32` excluded) and re-executes any scaffold script through it,
+  forwarding arguments and exit code; it carries no judgement of its own, so
+  there is no second implementation to drift from the canonical `.sh`. The
+  same edit stops the check's exit code being read as two answers when it has
+  three: tuned, not tuned, and *could not run* — the last is now reported as
+  itself rather than as "not onboarded". macOS and Linux are unaffected: their
+  command is unchanged (#49).
 - The `orchestrator` agent can now run the protocol it exists to run. Its
   `tools` allowlist granted `read`, `search`, `execute`, `agent` and
   `github/*` — and `tools` is strict, so every app session tool was


### PR DESCRIPTION
Closes #49

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/49#issuecomment-5281024014

## What

`bash .github/scripts/tuning-status.sh --quiet` reaches the WSL launcher on Windows **when nothing is misconfigured**. Git for Windows adds `…\Git\cmd` to `PATH` and leaves `…\Git\bin` off it on purpose, so `git` resolves and `bash` does not — while `System32\bash.exe` is on `PATH` by default. The app already requires Git, so the interpreter was always present; the instruction could not reach it.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| One reusable shim, not one `.ps1` per script | `.github/scripts/run.ps1 <script.sh> [args]` runs any scaffold script; resolves relative to `.github/scripts/` or as given |
| System32 skipped, install locations first, actionable failure | `Find-GitBash` searches `ProgramFiles` / `ProgramFiles(x86)` / `LocalAppData` before `PATH` and filters `System32`. Missing-bash message names Git for Windows and why. Test: "the search excludes System32", "standard install locations are searched before PATH", "an unresolvable bash fails with the Git for Windows message" |
| The shim carries no judgement | It forwards arguments and `$LASTEXITCODE`, parses nothing. Test greps for marker/exit-code logic and fails if any appears. **This is why the reported "test that both versions agree" is not implemented — there is one implementation** |
| Windows and non-Windows invocations stated; non-Windows unchanged | "First contact" names both. The non-Windows command is byte-identical; re-run here: `bash .github/scripts/tuning-status.sh --quiet` → rc=1, as before (this repository is the template and keeps its `CUSTOMIZE` markers) |
| Three answers, not two | "**0** means tuned. **1** means markers remain … **Anything else** … means the check did not run. Say that plainly … never report it as either answer" |
| Git for Windows stated as a prerequisite, with the reason | README Getting started: "the app already requires Git, and its `bash.exe` is what runs these scripts. Do not type `bash` there" |
| Test runs everywhere, skips loudly | `test-run-shim.sh`: 5 structural cases everywhere; 4 behavioural cases when an interpreter exists. Verified both ways — with PowerShell 9/9 pass; with it removed, 5 pass and the skip prints what was **not** executed |
| Verification wall | run-tests.sh 18 suites green; check-copilot-surface OK (both new files scanned by the English-only rule); shellcheck clean; check-md-links, check-changelog-refs OK |

### Writing it blind would have shipped two bugs

There is no PowerShell on this machine, so a build was fetched to a temp directory and the shim actually executed. That found:

1. **`$env:SystemRoot` is null off Windows** → `Join-Path` threw a parameter-binding error instead of the intended message.
2. **`Join-Path 'C:\Windows' 'System32'` resolves the drive** → fails anywhere without a `C:` drive, so the fix for (1) was itself broken.

Neither is fatal on Windows, but both sit on the path an adopter without Git Bash takes: they would have seen a binding error instead of "install Git for Windows". The prefix is now built by string concatenation, and a test asserts it stays that way.

## Deviations

**`scaffold-init.ps1` keeps its own copy of `Find-GitBash`.** The issue asked that the two not carry two copies. That file is fetched by URL and executed *before the repository exists* — it cannot dot-source a sibling that is not on disk yet. Sharing would mean a second network fetch inside the bootstrap, trading a duplicated 15-line search for a new failure mode during install. The duplication is the cheaper of the two, and `run.ps1` names the relationship so a reader finds both.

**The Windows path itself is unverified.** Everything above was exercised on macOS: the shim parses, resolves scripts, forwards arguments, and fails correctly when no Git Bash exists. What cannot be checked here is the case that matters most — resolving a *real* Git Bash and running `tuning-status.sh` through it. Per the issue's own condition, this is reported as **unverified, not as done**, and needs one run on a Windows machine:

```
pwsh .github/scripts/run.ps1 tuning-status.sh --quiet
echo $LASTEXITCODE   # expect 0 or 1 — never a PowerShell exception
```
