### PR TITLE
retro: run the Windows invocation on Windows

### DIFF
--- a/.github/docs/agreements/retro-log.md
+++ b/.github/docs/agreements/retro-log.md
@@ -6,4 +6,5 @@ why a rule exists (a rule with no traceable origin cannot be safely removed).
 
 | Date | Failure class | Fix (asset + change) | Evidence |
 |---|---|---|---|
+| 2026-08-13 | Surfaces shipped and stayed broken because nothing had ever executed them — an agent tool grant that never matched its protocol, and a Windows command that never reached Git Bash. Neither regressed; both were wrong from the day they were written, and both were found by adopters rather than here | `ci.yml`: a `windows-launcher` job runs the documented Windows invocation on a Windows runner, distinguishing a launcher that raises from a repository that reports untuned. (#47's counterpart wall, `check-agent-tools.sh`, shipped with its own fix) | Occurrences: #47, #49; fix in #51 |
 | 2026-08-08 | Supervisor archived before its workers, orphaning worker sessions (only a human can remove them; `archive_session` is creator-scoped) | `session-orchestration/SKILL.md`: leaf-first teardown order added to the app session-tree section | Occurrences: #117, #123 closeouts; fix in #127 |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,10 @@ jobs:
             throw "run.ps1 returned $code; tuning-status.sh --quiet documents 0 (tuned) or 1 (markers remain)."
           }
           "run.ps1 returned $code - Git Bash was resolved and the script ran."
+          # Actions appends `exit $LASTEXITCODE` to a pwsh step, so the code
+          # this step deliberately accepts would otherwise fail it. Reached
+          # only when both assertions above passed; a throw never gets here.
+          exit 0
 
       - name: Record what bare bash resolves to here
         shell: pwsh
@@ -234,3 +238,4 @@ jobs:
           $found = @(Get-Command bash -All -CommandType Application -ErrorAction SilentlyContinue |
             ForEach-Object { $_.Source })
           if ($found) { $found -join "`n" } else { "bash is not on PATH at all" }
+          exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,46 @@ jobs:
             exit 2
           }
           bash .github/scripts/check-copilot-surface.sh
+
+  # Why a Windows runner for one command: #47 and #49 both shipped broken and
+  # stayed broken, because nothing here had ever executed them (retro #51).
+  # Every other job runs on Linux, so the Windows launcher — the one surface
+  # adopters touch that CI never did — is exercised here the way they run it.
+  windows-launcher:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: The documented Windows invocation resolves Git Bash
+        shell: pwsh
+        run: |
+          # `--quiet` documents no output and an exit code only, so stderr
+          # holds a PowerShell error or nothing. That is the discriminator:
+          # a launcher that raises and a repository that still has CUSTOMIZE
+          # markers both leave the exit code at 1, and this repository is the
+          # template, so 1 is its normal answer.
+          & pwsh .github/scripts/run.ps1 tuning-status.sh --quiet 2> launcher-stderr.txt
+          $code = $LASTEXITCODE
+          $err = (Get-Content launcher-stderr.txt -Raw -ErrorAction SilentlyContinue)
+          Remove-Item launcher-stderr.txt -ErrorAction SilentlyContinue
+          if ($err) {
+            throw "run.ps1 raised instead of returning an exit code:`n$err"
+          }
+          if ($code -ne 0 -and $code -ne 1) {
+            throw "run.ps1 returned $code; tuning-status.sh --quiet documents 0 (tuned) or 1 (markers remain)."
+          }
+          "run.ps1 returned $code - Git Bash was resolved and the script ran."
+
+      - name: Record what bare bash resolves to here
+        shell: pwsh
+        run: |
+          # Diagnostic, never an assertion. A hosted runner's PATH is not a
+          # stock desktop's: if Git\bin happens to be on it here, bare `bash`
+          # works on this machine and would still fail for the adopter. This
+          # line is what tells a future reader which of the two they are
+          # looking at.
+          $found = @(Get-Command bash -All -CommandType Application -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.Source })
+          if ($found) { $found -join "`n" } else { "bash is not on PATH at all" }

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,17 @@ inherit what this one learned.
 
 ### Unreleased
 
+- CI now runs the documented Windows invocation on a Windows runner. Two
+  adopter reports in one day — the orchestrator's tool grant (#47) and the
+  Windows first-contact command (#49) — were the same failure: neither had
+  regressed, both were wrong from the day they were written, and nothing here
+  had ever executed either. Every job in `ci.yml` ran on Linux, so the
+  launcher adopters actually touch was the one surface CI never did. The new
+  `windows-launcher` job drives `run.ps1` the way an adopter does and tells a
+  raising launcher apart from a repository that merely reports untuned — the
+  two look identical through an exit code alone. Nothing was added to the
+  always-on instruction files: the job is the fix, and a sentence restating
+  it would be scar tissue (#51).
 - Windows can run the first-contact check. `bash` there reaches the WSL
   launcher, not Git Bash — the Git for Windows installer leaves `…\Git\bin`
   off `PATH` deliberately, while `System32\bash.exe` is on it by default, so


### PR DESCRIPTION
Closes #51

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/51#issuecomment-5281279316

## What

`retro:` PR for a failure class that appeared twice in one day. #47 and #49 were not two bugs — they were one: **surfaces that shipped broken and stayed broken because nothing had ever executed them.** Neither regressed. Both were wrong from the day they were written, and both were found by an adopter rather than here.

Every job in `ci.yml` ran on `ubuntu-latest`, so the Windows launcher — the one surface adopters touch that CI never did — is now exercised the way they run it.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| CI runs the documented Windows invocation on Windows | New `windows-launcher` job, `runs-on: windows-latest`, running `pwsh .github/scripts/run.ps1 tuning-status.sh --quiet` |
| The assertion separates launcher failure from "untuned" | `--quiet` documents no output and a code only, and this repository *is* the template, so exit 1 is its normal answer — and a raised error also exits 1. **stderr is the discriminator**: non-empty means the launcher raised; the code is then accepted only as 0 or 1 |
| Existing conventions followed | Same SHA-pinned `actions/checkout` as the other jobs, `persist-credentials: false`, inherits the workflow-level `contents: read` like `copilot-surface`, and carries a comment saying why it exists |
| Pin and permission guards pass | `check-action-pins.sh`: "All action references are SHA-pinned." `check-workflow-permissions.sh`: "OK — 16 job(s) checked" |
| retro-log row | One row: failure class, asset, occurrences #47 and #49 |
| Budget rule respected | **Nothing added** to `AGENTS.md` (117 lines) or `copilot-instructions.md` (117 lines). The job is the fix; a sentence restating it is exactly the scar tissue the skill warns against |
| #49's "unverified" discharged | See below — partly |
| Verification wall | run-tests.sh 18 suites green; check-copilot-surface OK; check-md-links, check-changelog-refs OK; `ci.yml` parses |

## On what this actually proves

The second step asserts nothing on purpose. **A hosted runner's `PATH` is not a stock desktop's.** If `Git\bin` happens to be on it, bare `bash` works on the runner and would still fail for the adopter — so a green job here does not reproduce their environment, and claiming otherwise would repeat the mistake #43 was raised about. The step records what `bash` resolves to so a future reader can tell which situation they are looking at.

What the job *does* prove is the part #49 could not check on macOS: that `run.ps1` **resolves a real Git Bash and runs a script through it**, returning that script's exit code rather than raising. That was the outstanding unverified claim, and it is now checked on every PR.

What remains unproven is narrower than before: the adopter's exact `PATH`, where bare `bash` reaches `System32`. That is untestable from CI by construction, and the launcher exists precisely so it does not matter.

## Note on the ledger step

The retro skill counts first occurrences via `retro:candidate` issues so the trigger has something durable to fire on. Here both occurrences were already durable issues (#47, #49), so filing a candidate and promoting it in the same breath would have been theatre. The issue is labelled `retro:candidate` and closed by this PR, which leaves the same trail.

## What the job recorded on its first green run

```
run.ps1 returned 1 - Git Bash was resolved and the script ran.
```

That is #49's outstanding claim, checked: the launcher **found a real Git Bash and ran a bash script through it**, returning the script's own exit code rather than raising. It could not be verified on macOS; it is now verified on every PR.

The diagnostic step, which asserts nothing, found three:

```
C:\Program Files\Git\bin\bash.exe
C:\Windows\system32\bash.exe          <- the WSL launcher, present as predicted
C:\Program Files\Git\usr\bin\bash.exe
```

Read it carefully, because it cuts both ways. `System32\bash.exe` **is** there, confirming the launcher this scaffold exists to avoid. But `Git\bin` is on the runner's `PATH` and comes first, so bare `bash` would have worked here — **the hosted runner is not a stock desktop, and this job does not reproduce the adopter's failure.** It proves the fix works, not that the bug is present. Saying otherwise would be the error #43 was raised about, so the step records the fact instead of asserting on it.

## The job's first act was to fail on itself

The first run asserted correctly, printed "Git Bash was resolved and the script ran", and then failed the step. Actions appends `exit $LASTEXITCODE` to a `pwsh` step, so `tuning-status.sh`'s exit 1 — the answer this step exists to *accept* — became the step's verdict.

Invisible off Windows CI, and invisible in review. A fitting first act for a job whose reason to exist is that this repository kept shipping things nobody had run.
