### PR TITLE
Say who runs the verification, so it stops running three times

### DIFF
--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -317,7 +317,9 @@ merge — a phase started against a half-tuned repository verifies nothing.
    prefer steering over restarting.
 5. On receiving a report: verify the record exists on the issue and spot-check
    the evidence with your own `gh` calls before updating labels/Project state
-   or dispatching dependents. An unrecorded report is returned to the child
+   or dispatching dependents — `gh` calls are the whole of it, because the
+   artifact is CI's to verify and not yours to rebuild (`verification`
+   §The layers). An unrecorded report is returned to the child
    with one instruction: record first. **Silence is checked the same way.** A
    child that wakes its parent having written nothing on the issue has not
    been quietly productive — it has not started, or it has died. Read the

--- a/.github/skills/verification/SKILL.md
+++ b/.github/skills/verification/SKILL.md
@@ -39,6 +39,20 @@ Never compensate for a lower layer at a higher one ("reviewer will catch it")
 and never weaken a lower layer to pass ("delete the flaky test"). A failing
 gate is information; removing the gate destroys the information.
 
+**The layers run once, not once per session tier.** Layer 1 runs twice by
+design — the implementer runs it, then CI runs it — and CI's run is the
+authoritative one, which every session above reads through `gh pr checks`. So
+a supervising session verifies the **record**: the evidence table, the CI
+verdict, the diff against the ownership paths. It does not rebuild the
+artifact. Re-run a command only to resolve something specific — records that
+contradict each other or CI, evidence that is absent, a claim implausible on
+its face — and say which contradiction you were resolving. This sharpens
+verify-before-done rather than relaxing it: every ground truth `AGENTS.md` §3
+names (`git status`, `gh issue view`, `gh pr view`, `gh pr checks`) is a read
+of the record, not a build. Reading the record *is* the check, never a way
+around it — an absent or hand-waved evidence table still goes back to the
+child with one instruction: record first.
+
 ## Pre-PR checklist (implementer)
 
 1. Run every command in the Task issue's **Verification** section; capture

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- A supervising session verifies the record, not the artifact. An adopter
+  measured three runs of the same verification for one result — supervisor,
+  Epic orchestrator and program session each running `gh pr view` and the same
+  build, with one task's RAM/Flash measurement executed twice and logged by the
+  Epic session itself as a coordination failure. Nothing here told them not to:
+  `verification`'s layers are CI layers, and they never said who runs them. They
+  now say it. Layer 1 runs twice by design — implementer, then CI — and CI's run
+  is authoritative, read from above through `gh pr checks`; a tier above
+  verifies the evidence table, the CI verdict and the diff against ownership,
+  and re-runs a command only to resolve a contradiction it can name. This
+  sharpens verify-before-done rather than relaxing it: every ground truth
+  `AGENTS.md` §3 lists is a read of the record, not a build (#55).
 - CI now runs the documented Windows invocation on a Windows runner. Two
   adopter reports in one day — the orchestrator's tool grant (#47) and the
   Windows first-contact command (#49) — were the same failure: neither had


### PR DESCRIPTION
Closes #55

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/55#issuecomment-5290328550

## What

An adopter measured where their time went and found verification running **three times for one result**: supervisor, Epic orchestrator and program session each ran `gh pr view` and the same build. On one task the Epic session and its supervisor ran the same RAM/Flash measurement — logged by the Epic session itself as a coordination failure.

The scaffold never said who runs what. `verification`'s layers are CI layers, so "verify" read as "verify again" at every tier.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| A supervising session verifies the record and the CI verdict, not the artifact | `verification` §The layers: "Layer 1 runs twice by design — the implementer runs it, then CI runs it — and CI's run is the authoritative one, which every session above reads through `gh pr checks`. So a supervising session verifies the **record** … It does not rebuild the artifact" |
| The exception is bounded and nameable | "Re-run a command only to resolve something specific — records that contradict each other or CI, evidence that is absent, a claim implausible on its face — and say which contradiction you were resolving" |
| Sharpens §3 rather than weakening it | "every ground truth `AGENTS.md` §3 names (`git status`, `gh issue view`, `gh pr view`, `gh pr checks`) is a read of the record, not a build" |
| Not a licence to accept an unverified claim | "Reading the record *is* the check, never a way around it — an absent or hand-waved evidence table still goes back to the child with one instruction: record first" |
| The dispatch loop points, does not restate | Step 5 gains one clause: "`gh` calls are the whole of it, because the artifact is CI's to verify and not yours to rebuild (`verification` §The layers)" |
| Budget | `verification` 109 → 123 (ceiling 500); `session-orchestration` 432 → 434; **`AGENTS.md` unchanged at 117** |
| Verification wall | check-copilot-surface OK; run-tests.sh 18 suites green; check-md-links, check-escalation-wording, check-changelog-refs OK |

## Deviations

None to the issue. Worth recording about the report it came from: **one of its claims did not survive checking.** It listed `gh issue view --json blockedBy` as invalid on gh 2.96.0; run here on the same version it returns `{"blockedBy":{"nodes":[],"totalCount":0}}`, and `frontier.sh` depends on it. Two more CLI complaints (`gh pr diff <n> -- <path>`, heredoc bodies) are real gh behaviours that this scaffold never instructs — `plan-management` already uses `--body-file`. Those items were left alone rather than "fixed", and the rest of the report (a threshold for the small-task exemption, environment preconditions in onboarding, retro-promotion timing) needs design and rides a later issue.

The reporter's own framing of their biggest cost — unbounded inter-session messages — is deliberately **not** implemented. "Pointer, not payload", "short course-correction messages" and §6's escalate-as-an-issue-comment already exist; the discipline was not followed, and adding "be brief" would be the vague-morals anti-pattern the retro skill warns against.
