### PR TITLE
Stop failing the pull request that installs the wall

### DIFF
--- a/.github/scripts/check-task-ritual.sh
+++ b/.github/scripts/check-task-ritual.sh
@@ -62,7 +62,7 @@
 # Usage:
 #   check-task-ritual.sh [<pr-number>]     # or set PR_NUMBER
 #
-# Exemptions — two, both narrow:
+# Exemptions — three, all narrow:
 #   1. Allowlisted dependency bots skip the ritual (default: dependabot[bot]
 #      renovate[bot] github-actions[bot]; override with RITUAL_EXEMPT_BOTS,
 #      space-separated logins). Any other bot author — cloud coding agents
@@ -75,6 +75,10 @@
 #      CUSTOMIZE markers. Those last two make the exemption self-limiting: it
 #      holds at most once per adopting repository and lapses the moment
 #      onboarding merges.
+#   3. The adoption PR — the one that installs the scaffold. Its base has no
+#      AGENTS.md and it adds both AGENTS.md and copilot-instructions.md.
+#      No title is involved: adoption PRs have no naming convention. Also
+#      self-limiting — after the merge the base has AGENTS.md forever.
 #
 # Requires: GitHub CLI (gh), authenticated. Repo context comes from the
 # checkout ({owner}/{repo} placeholders); set GH_REPO to override.
@@ -171,6 +175,48 @@ if printf '%s\n' "$title" | grep -qE '^scaffold: onboard '; then
     echo "      already onboarded;"
   fi
   echo "      the full start ritual applies."
+fi
+
+# The adoption PR — the one that *installs* this scaffold — has no upstream
+# Task either, and for a stronger reason: when it opens, the repository has no
+# scaffold, usually no issues, and the workflow doing this enforcing arrives in
+# that very diff. Exemption 2 cannot cover it; its self-limiting signal asks
+# whether the base is already adopted, which is exactly what an adoption PR is
+# not.
+#
+# This path is ours to support, not an edge case. The installer stages without
+# committing, and README step 4 recommends a ruleset on `main` that *requires* a
+# pull request — so an adopter who follows that advice cannot push the adoption
+# commit directly, and the only route left is the one this exemption unblocks.
+#
+# Every signal is structural. Title is not among them: adoption PRs have no
+# naming convention (the reported one read "Add Agentic Dev Kit for Copilot
+# scaffold"), and a title an author chooses is not evidence anyway.
+#
+#   1. the base carries no AGENTS.md — read at ?ref=<base>, so the workflow's
+#      checkout is irrelevant;
+#   2. this PR adds AGENTS.md (status "added", not "modified");
+#   3. it also adds .github/copilot-instructions.md, so a repository writing an
+#      AGENTS.md of its own cannot claim the exemption.
+#
+# Self-limiting by construction: after the merge the base has AGENTS.md, so
+# signal 1 can never hold again there. This template excludes itself the same
+# way — main carries the scaffold.
+if ! api "repos/{owner}/{repo}/contents/AGENTS.md?ref=${base_ref}" --jq '.sha' >/dev/null 2>&1; then
+  # A 3000-file listing cap applies; the scaffold is ~90 files, so a PR that
+  # hits the cap is not an adoption PR and simply fails the signal below.
+  added=$(api "repos/{owner}/{repo}/pulls/${PR}/files?per_page=100" --paginate \
+    --jq '[.[] | select(.status == "added") | .filename]' 2>/dev/null || echo '[]')
+  adds_agents=$(printf '%s' "$added" | grep -c '"AGENTS.md"' || true)
+  adds_instructions=$(printf '%s' "$added" | grep -c '"\.github/copilot-instructions\.md"' || true)
+
+  if [[ "$adds_agents" -ge 1 && "$adds_instructions" -ge 1 ]]; then
+    echo "PASS: PR #${PR} adopts the scaffold — base '${base_ref}' has no AGENTS.md,"
+    echo "      and this PR adds AGENTS.md and .github/copilot-instructions.md."
+    echo "      No Task issue can exist yet: the ritual this wall enforces arrives"
+    echo "      in this diff. The exemption lapses the moment this merges."
+    exit 0
+  fi
 fi
 
 # The first task link names the primary Task under review. A qualifier may sit

--- a/.github/scripts/tests/lib.sh
+++ b/.github/scripts/tests/lib.sh
@@ -101,8 +101,10 @@ case "$path" in
   user) fixture="$GH_FIXTURES/user.json" ;;
   orgs/*) fixture="$GH_FIXTURES/org.json" ;;
   repos/*/pulls/*/commits) fixture="$GH_FIXTURES/commits.json" ;;
+  repos/*/pulls/*/files*) fixture="$GH_FIXTURES/pull-files.json" ;;
   repos/*/pulls/*) fixture="$GH_FIXTURES/pull.json" ;;
   repos/*/contents/SCAFFOLD-CHANGELOG.md*) fixture="$GH_FIXTURES/contents-changelog.json" ;;
+  repos/*/contents/AGENTS.md*) fixture="$GH_FIXTURES/contents-agents.json" ;;
   repos/*/contents/*) fixture="$GH_FIXTURES/contents.json" ;;
   repos/*/issues/comments/*) fixture="$GH_FIXTURES/comment.json" ;;
   repos/*/issues/*/comments) fixture="$GH_FIXTURES/comments.json" ;;
@@ -112,7 +114,11 @@ case "$path" in
   repos/*) fixture="$GH_FIXTURES/repo.json" ;;
   *) echo "gh shim: no fixture mapped for '$path'" >&2; exit 64 ;;
 esac
-[ -f "$fixture" ] || { echo "gh shim: missing fixture $fixture" >&2; exit 64; }
+# An absent fixture stands for a 404. The scaffold reads several paths that
+# legitimately do not exist (a base branch without AGENTS.md is the whole
+# signal of the adoption exemption), so a missing file must fail the way the
+# API does — exit 1 — not as a shim error.
+[ -f "$fixture" ] || { echo "gh: Not Found (HTTP 404)" >&2; exit 1; }
 jq -r "$jq_expr" "$fixture"
 SHIM
   chmod +x "$1/bin/gh"

--- a/.github/scripts/tests/test-ritual-adoption.sh
+++ b/.github/scripts/tests/test-ritual-adoption.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-ritual-adoption.sh — regression tests for the adoption exemption in
+# .github/scripts/check-task-ritual.sh.
+#
+# The PR that installs this scaffold has no Task issue to link: when it
+# opens, the repository has no scaffold, usually no issues, and the workflow
+# doing the enforcing arrives in that very diff. An adopter hit exactly that
+# and needed an admin merge (#53). Exemption 2 cannot cover it — its
+# self-limiting signal asks whether the base is *already* adopted.
+#
+# What these cases pin is that the exemption is narrow and cannot be claimed
+# by an ordinary PR: the base must genuinely lack AGENTS.md, and the diff
+# must genuinely add both AGENTS.md and copilot-instructions.md. A missing
+# contents fixture stands for a 404, which is how "the base has no scaffold"
+# is expressed here.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+GUARD="$REPO_ROOT/.github/scripts/check-task-ritual.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/adopttest.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+install_gh_shim "$WORK"
+
+# The reported PR: no task link, no plan, no issues in the repository. If the
+# exemption does not fire, everything after it fails — which is the point.
+PULL_ADOPTION='{"user":{"login":"mochan-tk","type":"User"},"title":"Add Agentic Dev Kit for Copilot scaffold","body":"Closes #N/A\n\nPlan: N/A (scaffold bootstrap, no Task issue)","base":{"ref":"main"}}'
+
+FILES_SCAFFOLD='[{"filename":"AGENTS.md","status":"added"},{"filename":".github/copilot-instructions.md","status":"added"},{"filename":".github/workflows/ci.yml","status":"added"}]'
+FILES_AGENTS_ONLY='[{"filename":"AGENTS.md","status":"added"}]'
+FILES_ORDINARY='[{"filename":"src/main.c","status":"added"},{"filename":"README.md","status":"modified"}]'
+
+# new_case <pull-json> <files-json> [base-has-agents] — writes fixtures and
+# sets CASE. Omitting the third argument leaves contents-agents.json absent,
+# which the shim answers as 404: a base with no scaffold.
+SANDBOX_N=0
+new_case() {
+  SANDBOX_N=$((SANDBOX_N + 1))
+  CASE="$WORK/case$SANDBOX_N"
+  mkdir -p "$CASE"
+  printf '%s\n' "$1" > "$CASE/pull.json"
+  printf '%s\n' "$2" > "$CASE/pull-files.json"
+  printf '%s\n' '{"full_name":"o/r"}' > "$CASE/repo.json"
+  printf '%s\n' '[]' > "$CASE/comments.json"
+  printf '%s\n' '[]' > "$CASE/commits.json"
+  printf '%s\n' '{"labels":[]}' > "$CASE/issue.json"
+  [ $# -ge 3 ] && printf '%s\n' '{"sha":"abc1234","content":""}' > "$CASE/contents-agents.json"
+  return 0
+}
+
+# --- the adoption PR passes ------------------------------------------------
+new_case "$PULL_ADOPTION" "$FILES_SCAFFOLD"
+GH_FIXTURES="$CASE" expect_rc_grep 0 'adopts the scaffold' \
+  "a PR adding the scaffold to a repository without one passes" \
+  bash "$GUARD" 1
+
+# --- and lapses the moment it has merged -----------------------------------
+# Same PR, same diff; the only change is that the base now has AGENTS.md.
+# This is the whole self-limiting argument, so it is pinned rather than
+# argued: after the merge the exemption can never hold in that repository.
+new_case "$PULL_ADOPTION" "$FILES_SCAFFOLD" base-has-agents
+GH_FIXTURES="$CASE" expect_rc_grep 1 'no task link' \
+  "the same PR against an adopted base is held to the ritual" \
+  bash "$GUARD" 1
+
+# --- adding AGENTS.md alone is not adopting --------------------------------
+# A repository writing its own agent notes must not inherit the exemption.
+new_case "$PULL_ADOPTION" "$FILES_AGENTS_ONLY"
+GH_FIXTURES="$CASE" expect_rc_grep 1 'no task link' \
+  "adding AGENTS.md without copilot-instructions.md is not an adoption" \
+  bash "$GUARD" 1
+
+# --- an ordinary PR cannot claim it ----------------------------------------
+new_case "$PULL_ADOPTION" "$FILES_ORDINARY"
+GH_FIXTURES="$CASE" expect_rc_grep 1 'no task link' \
+  "a PR touching neither scaffold file is held to the ritual" \
+  bash "$GUARD" 1
+
+# --- a modified AGENTS.md is not an added one ------------------------------
+# Retro PRs amend AGENTS.md routinely; if "modified" counted, every one of
+# them against a scaffold-less base would skip the ritual.
+new_case "$PULL_ADOPTION" \
+  '[{"filename":"AGENTS.md","status":"modified"},{"filename":".github/copilot-instructions.md","status":"added"}]'
+GH_FIXTURES="$CASE" expect_rc_grep 1 'no task link' \
+  "modifying AGENTS.md rather than adding it is not an adoption" \
+  bash "$GUARD" 1
+
+t_summary

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ bash ≥ 3.2).
    - Stages the files without committing and records the adoption in
      `SCAFFOLD-CHANGELOG.md`; the seeded `.gitattributes` pins scaffold
      paths to LF so the bash scripts survive Windows checkouts.
+   - Commit them however your repository works — directly on the default
+     branch, or through a pull request. Step 4's ruleset makes the pull
+     request mandatory once it is in place, so the ritual wall exempts the
+     PR that adds `AGENTS.md` and `copilot-instructions.md` to a repository
+     that has neither. It has no Task issue to link because it is what
+     brings the ritual with it.
    - Safety: collisions refuse unless you pass `--force`; `--dry-run`
      previews the plan and writes nothing; symlinked paths always
      refuse; the fetch is pinned to a commit SHA resolved before

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,18 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The PR that installs the scaffold is no longer failed by the wall it
+  installs. An adopter opened one and `task-ritual` rejected it for having no
+  Task link — in a repository with no issues, no `AGENTS.md` on `main`, and
+  the enforcing workflow arriving in that very diff. The onboarding exemption
+  could not help: its self-limiting signal asks whether the base is already
+  adopted, which an adoption PR is by definition not. This path is ours to
+  support rather than an edge case, since README step 4 recommends a ruleset
+  that *requires* a pull request. A third exemption now covers it, on
+  structural signals only — the base has no `AGENTS.md`, and the PR adds both
+  `AGENTS.md` and `.github/copilot-instructions.md`. No title is involved:
+  adoption PRs have no naming convention. It is self-limiting the same way
+  the second one is — after the merge the base has `AGENTS.md` forever (#53).
 - A supervising session verifies the record, not the artifact. An adopter
   measured three runs of the same verification for one result — supervisor,
   Epic orchestrator and program session each running `gh pr view` and the same


### PR DESCRIPTION
Closes #53

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/53#issuecomment-5290622323

## What

An adopter installed the scaffold through a pull request and `task-ritual` failed it for having no Task link. There was none to give: the repository had no issues, `main` had no `AGENTS.md`, and the workflow doing the enforcing arrived in that diff. **The adoption PR was judged by the wall it installs**, and merging took an admin override.

Not an edge case. README step 4 recommends a ruleset on `main` that *requires* a pull request — so an adopter who follows our own advice cannot push the adoption commit directly.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| An adoption PR passes without an admin override | New exemption in `check-task-ritual.sh`; test "a PR adding the scaffold to a repository without one passes" uses the reported PR's exact body (`Closes #N/A`, `Plan: N/A (scaffold bootstrap, no Task issue)`) |
| Self-limiting by construction | The base signal is `AGENTS.md` absent at `?ref=<base>`; after the merge it is present forever. **Verified against the real PR**: at its base sha `c5e79d5` the file 404s, on `main` today it resolves to `d575018`. Pinned by the test "the same PR against an adopted base is held to the ritual" |
| Cannot be claimed by an ordinary PR | Three tests: adding `AGENTS.md` alone fails; touching neither file fails; **`modified` rather than `added` fails** — retro PRs amend `AGENTS.md` routinely, and counting `modified` would hand them the exemption |
| This template cannot claim it | `main` here carries the scaffold, so signal 1 is false. Demonstrated by this PR: its own `task-ritual` is **not** exempt and passes the full ritual |
| Both directions tested | `test-ritual-adoption.sh`, 5 cases green |
| Header comment stays accurate | Enumerates three exemptions, not two |
| Documented where adopters meet it | README installer section: committing via pull request is supported, and why the exemption exists |
| Verification wall | run-tests.sh **19 suites green**; shellcheck clean on all three changed shell files; check-copilot-surface, check-md-links, check-changelog-refs OK |

## Design notes

**No title signal.** The reported PR was titled `Add Agentic Dev Kit for Copilot scaffold`; adoption PRs have no naming convention, and a title the author chooses is not evidence. Exemption 2 can afford a title because the onboarding skill mandates one — this one cannot, so all three signals are structural.

**A missing fixture now means 404.** The gh shim used to treat one as a shim error. The primary signal here is a file that *does not exist*, so the test harness had to be able to express absence. Existing suites re-verified: 19/19 green.

## Deviations

None. The exemption is one more narrow case, not a softening: every other PR still needs its Task link, and the `type:task` label, plan-comment and chronology checks are untouched.
