### PR TITLE
Keep the kit's guard tests out of adopters' repositories

### DIFF
--- a/.github/scripts/tests/run-tests.sh
+++ b/.github/scripts/tests/run-tests.sh
@@ -6,12 +6,42 @@
 # the network: GitHub API reads are served by a PATH shim over recorded
 # fixtures, and filesystem guards run against throwaway git sandboxes.
 #
-# Usage: bash .github/scripts/tests/run-tests.sh
-# Exit: 0 when every test file passes, 1 on any failure, 2 on a missing
-# dependency. Dependencies: bash 3.2+, git, jq (for the gh shim).
+# These tests belong to the kit, not to the projects that adopt it. They
+# exercise scaffold machinery — the installer's symlink refusal, the ritual
+# wall's exemptions, the gh fixture shim — none of which an adopting project
+# owns or can act on. So they decline to run outside the template, and say so
+# in a line instead of costing six minutes and, on Windows, failing (#58).
+# The signal is the scaffold-version marker: `sha=unknown` is the template
+# itself, a real commit sha is an adopting repository (the same discriminator
+# the ritual wall's onboarding exemption uses). Set FORCE_GUARD_TESTS=1 to run
+# them anywhere — a fork, or a checkout without the marker.
+#
+# Usage: bash .github/scripts/tests/run-tests.sh [suite ...]
+#   suite: a test file name, with or without the test- prefix and .sh suffix,
+#          or a substring of one — `run-tests.sh ritual` runs every ritual
+#          suite. No arguments runs all of them.
+# Exit: 0 when every test file passes (or when declining), 1 on any failure,
+# 2 on a missing dependency or an unmatched suite name.
+# Dependencies: bash 3.2+, git, jq (for the gh shim).
 
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+if [ "${FORCE_GUARD_TESTS:-0}" != "1" ]; then
+  marker="$ROOT/SCAFFOLD-CHANGELOG.md"
+  # An adopted scaffold records the commit it came from; the template's own
+  # copy has nothing to record and reads `sha=unknown`. A missing marker file
+  # means neither, so the tests run — a bare checkout of this repository is
+  # the likeliest cause and a contributor is the likeliest owner.
+  if [ -f "$marker" ] && ! grep -q '^<!-- scaffold-version: .* sha=unknown ' "$marker"; then
+    echo "skip - these tests verify the scaffold's own machinery, so they do not"
+    echo "       run in a repository that adopted it. Your project's checks are"
+    echo "       the ones in .github/copilot-instructions.md; the guards here are"
+    echo "       covered by the kit's CI. Set FORCE_GUARD_TESTS=1 to run anyway."
+    exit 0
+  fi
+fi
 
 for dep in git jq; do
   command -v "$dep" >/dev/null 2>&1 || {
@@ -20,10 +50,43 @@ for dep in git jq; do
   }
 done
 
+# Selecting suites: match each argument as a substring of a file's base name,
+# so `ritual-adoption`, `test-ritual-adoption` and `test-ritual-adoption.sh`
+# all reach the same file, and `ritual` reaches every ritual suite. An
+# argument that matches nothing is an error rather than a silent empty run.
+selected=()
+if [ "$#" -gt 0 ]; then
+  for want in "$@"; do
+    found=0
+    for t in "$HERE"/test-*.sh; do
+      [ -e "$t" ] || continue
+      case "$(basename "$t")" in
+        *"$want"*) selected[${#selected[@]}]="$t"; found=1 ;;
+      esac
+    done
+    [ "$found" -eq 1 ] || {
+      echo "error: no test file matches '$want'." >&2
+      printf '       available:' >&2
+      for t in "$HERE"/test-*.sh; do printf ' %s' "$(basename "$t")" >&2; done
+      printf '\n' >&2
+      exit 2
+    }
+  done
+else
+  for t in "$HERE"/test-*.sh; do
+    [ -e "$t" ] || { echo "error: no test files found in $HERE" >&2; exit 2; }
+    selected[${#selected[@]}]="$t"
+  done
+  # Six minutes was read as a hang in this repository's own work, by the
+  # person who wrote the tests. Saying so costs one line.
+  echo "Running the full guard suite; expect roughly six minutes."
+  echo "Pass a suite name to run one — for example: run-tests.sh ritual-adoption"
+  echo
+fi
+
 failed=0
 total=0
-for t in "$HERE"/test-*.sh; do
-  [ -e "$t" ] || { echo "error: no test files found in $HERE" >&2; exit 2; }
+for t in ${selected[@]+"${selected[@]}"}; do
   total=$((total + 1))
   echo "== $(basename "$t")"
   if bash "$t"; then

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -213,6 +213,13 @@ unrun command.
 end (or documented-red with a linked issue); `copilot-setup-steps.yml`
 executes via its own workflow_dispatch. Definition of tuned = all three.
 
+Those three, plus the project's own commands from P3, are the whole of P5.
+Do not reach past them into the kit's internals: `.github/scripts/tests/`
+verifies scaffold machinery — the installer, the ritual wall, the fixture
+shim — which an adopting project neither owns nor can act on, and which is
+covered by the kit's own CI. Run in an adopting repository the suite declines
+and says so; the minutes it would have cost are not a gap in the evidence.
+
 ### P6 — Record
 
 One PR titled `scaffold: onboard <project>`: the Triangle diffs, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
 
       # The guards guard the repo; these tests guard the guards. Offline
       # regression cases (sandbox repos + a gh fixture shim) must pass
-      # before the walls below are trusted.
+      # before the walls below are trusted. They are the kit's own, not an
+      # adopting project's: in a repository that installed the scaffold this
+      # step prints one line and exits 0, because the machinery under test
+      # belongs to us and its CI is here (#58).
       - name: Guard regression tests
         run: bash .github/scripts/tests/run-tests.sh
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,21 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The kit's guard tests stay home. An adopter onboarding an existing project
+  spent over an hour, roughly thirty minutes of it inside `run-tests.sh` —
+  investigating seven Windows failures in tests they had not touched, for
+  machinery their project does not use. Nothing ever told them to run it:
+  `run-tests.sh` appears in no skill or instruction, but P5 asks for green CI
+  and `ci.yml` runs the suite, so every adopter inherited it. The tests now
+  decline outside the template, keyed on the `scaffold-version` marker
+  (`sha=unknown` is the template, a real sha is an adopter) — which reaches
+  repositories that already have `ci.yml`, since `--upgrade` never refreshes
+  workflows. `FORCE_GUARD_TESTS=1` overrides. The runner also takes suite
+  names, so one failing suite re-runs in seconds instead of six minutes, and
+  it now prints that expected runtime up front: this repository's own
+  maintainer read those six minutes as a hang, twice, on the day this was
+  written. P5 says plainly that it does not reach into the kit's internals
+  (#58).
 - The PR that installs the scaffold is no longer failed by the wall it
   installs. An adopter opened one and `task-ritual` rejected it for having no
   Task link — in a repository with no issues, no `AGENTS.md` on `main`, and


### PR DESCRIPTION
Closes #58

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/58#issuecomment-5294777701

## What

An adopter onboarding an existing FastAPI + Next.js project spent over an hour, roughly thirty minutes inside `run-tests.sh` — investigating seven Windows failures in tests they had not touched, exercising machinery their project does not contain.

**Nothing ever told them to run it.** `run-tests.sh` appears in no skill, prompt or instruction. P5 asks for green CI, `ci.yml` runs the suite, and the suite ships with `.github/**`.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Adopters do not run the kit's guard tests | `run-tests.sh` declines outside the template. **Verified against v5's real marker** (`sha=703445b…`, fetched from the repository): prints the skip line, exits 0 |
| Reaches repositories that already have `ci.yml` | The decision lives in the script, not the workflow — `scaffold-init.sh:300` classes `.github/workflows/*` as `tuned`, so `--upgrade` never refreshes it. v3, v4 and v5 get this by upgrading scripts alone |
| The template still runs the full suite | 19 suites green here in **6m5s**; this PR's own `scaffold-self-check` is the live proof |
| Selective re-runs | `run-tests.sh ritual-adoption` → **17s**. Patterns work (`run-tests.sh agent-tools changelog` → 2 suites). An unmatched name is an error listing what exists, not a silent empty pass |
| P5 states what it requires | "Those three, plus the project's own commands from P3, are the whole of P5. Do not reach past them into the kit's internals" |
| Runtime is stated where someone waits | First two lines of a full run: "expect roughly six minutes", plus how to run one suite |
| Escape hatch | `FORCE_GUARD_TESTS=1` runs them anywhere — verified in the simulated adopter checkout |
| Verification wall | check-action-pins, check-workflow-permissions, check-copilot-surface, check-md-links, check-changelog-refs all OK; shellcheck clean at `-S style` |

## Why it was there

The installer's rule is that the scaffold owns `.github/**`, with exclusions named one by one — `LICENSE`, `.vscode/`, `.devcontainer/`. The judgement "kit-development things do not ship" **existed and was applied** to `.devcontainer/`. It was never applied to `.github/scripts/tests/`, because that path sat inside a directory already spoken for. A correct rule about ownership hid a distinction inside it.

Then classification froze the mistake: `ci.yml` is `tuned`, so the wrong thing shipped *and* fell outside the upgrade path. Hence the fix lives in the script.

## The audit promised in the plan

Checked the rest of `.github/` for the same class of stowaway. One near miss: `adopter-feedback.yml` runs in adopter repositories on every opened issue — but that is deliberate (it is the *sending* end of the consent-gated loop), it does nothing without the marker, and its header already reasons about "adopter copies of this file". Left alone. No other kit-only artifact ships.

## Deviations

**No `onboarding-check.sh`.** The reporter proposed a 1–2 minute onboarding-specific check. P5 already names its checks; a second script would be a second answer to a question that has one, and would drift from CI. Naming the existing commands is tried first.

**The seven Windows failures are not fixed here.** Once the suite stops running in adopter repositories they are the template's problem, on the template's CI. Fixing them now would repair the symptom that made a misplaced job visible instead of the misplacement.
