### PR TITLE
Say what this is for before saying how it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,92 @@
        width="200" alt="A circular emblem: a fairy conductor, eyes closed, raising a baton as notes drift upward">
 </p>
 
-# Agentic Development Scaffold (GitHub-native)
+# Agentic Development Kit
 
-Repository wiring for running an AI-agent development lifecycle on GitHub —
-conducted from the **GitHub Copilot app**, whose parent/child sessions carry
-the orchestration model, with the Copilot cloud (coding) agent, Copilot CLI
-and IDE agents executing individual tasks — such that **the plan,
-the work, the evidence, and the lessons all live on GitHub**, not in chat
-windows. Everything here is plain files: version it, review it, and let the
-improvement loops evolve it.
+Three things go wrong when you hand work to AI agents. You cannot **see** what
+was done. Decisions **scatter** across chat windows. And you are never sure
+**how much** you can safely delegate. This repository is a working answer to
+those three — as plain files you can version, review and change.
 
-Two design premises. First, sessions are ephemeral and agents are stateless,
-so GitHub (issues, PRs, committed files) is the only shared memory. Second,
-**this scaffold is generic by design**: project truth is injected once,
-through the `project-onboarding` skill, and kept honest afterwards by
-`.github/scripts/tuning-status.sh` — so the same template serves any project and can
-be sharply tuned the moment a target arrives.
+**Agentic Development** is the name for that answer: a layer of practice laid
+over the process you already run. Waterfall, Scrum, Kanban — it replaces none
+of them. Requirements, design, implementation, test and release stay exactly
+where they are. What changed is *who does the work*. The moment a worker with
+no memory joins the team, the process quietly loses the human recall and
+oversight it was always built on. This layer fills that hole.
 
-The execution plane is **Copilot-native**: the GitHub ledger and
+## Two theses
+
+It starts somewhere unremarkable: **an AI agent is a new team member.** You
+hand a colleague work as an issue, take delivery as a pull request, and judge
+quality by review. GitHub already carries that machinery, so working with
+agents needs no new one.
+
+The analogy then breaks in exactly three places, and everything here follows
+from them. An agent **loses its memory every morning** — yesterday's agreement
+and the correction you typed are both gone. It **multiplies faster than you
+can watch** — three capable colleagues become ten overnight. And its
+**probation never ends** — trust does not accumulate the way it does with a
+human hire.
+
+From the first break comes the thesis the rest hangs on: **conversation
+evaporates; only what lands in the repository and its issues persists.** Not a
+slogan, a definition. A commit, an issue, a pull request comment — those are
+landings. A brilliant exchange inside a session is not, and by tomorrow it is
+indistinguishable from something that never happened.
+
+Three disciplines fall out of that, and they are the floor everything else
+stands on. **record-before-report**: the outcome is written to the issue
+before anyone is told. **verify-before-done**: a claim of completion cites a
+command or a check, never a memory. **single-writer**: parallel tasks never
+share a file, or the plan serialises them instead.
+
+## The system learns
+
+A first failure is information. **The second of the same kind is a pattern**,
+and a pattern is answered with mechanism, not with a reminder in chat — you
+are talking to a colleague who forgets every morning. Land the lesson in a
+file and it reaches every surface and every future session at once. That is
+the `retro` loop, and it is why failure rates fall over a project's life: not
+because the models got smarter, but because the conventions grew.
+
+Some lessons turn out not to be about your project at all. Those go back to
+the template this kit ships as, so the next project starts where the last one
+finished — organizational learning, compounding.
+
+## Start where you are
+
+None of this has to arrive at once.
+
+- **Level 1 — record-before-report.** Make agents write results into issues
+  and pull requests first. Doable today, and "invisible" starts shrinking
+  immediately.
+- **Level 2 — delegate one task properly.** Write one self-contained issue,
+  hand it to an agent, watch CI go green, land the merge. One small loop, and
+  it doubles as the trial run for how much you can delegate.
+- **Level 3 — full operation.** Verification gates, the actionable frontier,
+  parallel sessions, the learning loops above.
+
+You can tell which step you are on by the shape of the pain. Results scattered
+across chat windows? Start at 1. Delegation works, but only for the one person
+who knows the trick? Start at 2. Already running work in parallel? Take the
+Level 3 parts in whatever order hurts most.
+
+## How it is put together
+
+Everything here is plain files: version them, review them, let the loops
+change them. Two properties shape the rest. The kit is **generic by design** —
+project truth is injected once, through the `project-onboarding` skill, and
+kept honest afterwards by `.github/scripts/tuning-status.sh`, so the same
+template serves any project and can be sharply tuned the moment a target
+arrives. And its execution plane is **Copilot-native**: the GitHub ledger and
 `AGENTS.md` stay platform-neutral, while every other agent-facing surface —
 skills, custom agents, prompts, instruction files, CI walls — is built for
-GitHub Copilot exclusively. Other platforms get the constitution and the
-ledger — nothing else is promised.
+GitHub Copilot exclusively. The lifecycle is conducted from the **GitHub
+Copilot app**, whose parent/child sessions carry the orchestration model, with
+the Copilot cloud (coding) agent, Copilot CLI and IDE agents executing
+individual tasks. Other platforms get the constitution and the ledger —
+nothing else is promised.
 
 Human judgment does not spread evenly across this lifecycle; it concentrates
 at dispatch and at the **Three Merges**: the **agreement merge** (a
@@ -65,7 +129,7 @@ docs/                              This repository's own development records: co
   instructions/                    Path-scoped rules (.github/docs/, firmware/, code review)
   agents/                          Roles: orchestrator, planner, reviewer (*.agent.md)
   skills/                          Procedures (SKILL.md each):
-    project-onboarding/              tune this scaffold to the target project
+    project-onboarding/              tune the installed scaffold to the project
     context-collection/              intake with provenance
     context-distillation/            agreements + context tiering
     plan-management/                 issue graph, frontier, replanning
@@ -313,7 +377,7 @@ bash ≥ 3.2).
      a `Retro hygiene review <YYYY-MM>` issue surfacing promotion-overdue
      retro candidates and always-on budget drift.
    *Done when:* the first task PR merges with its evidence table — you have
-   closed the loop once, and the scaffold is carrying your project.
+   closed the loop once, and the kit is carrying your project.
 
 ## Scaffold lineage & upgrades (the second loop)
 

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,22 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The README says what the kit is for before it says how it is built. Its
+  opening called this "an AI-agent development lifecycle" — which reads as a
+  kit for *building* AI agents, the opposite of the truth — and then spent
+  thirty lines on repository wiring, design premises and the execution plane
+  without naming a single problem any of it solves. It now opens with the
+  three pains (work you cannot see, decisions that scatter, not knowing how
+  much to delegate), defines **Agentic Development** as a layer over the
+  process a reader already runs rather than a replacement for it, and states
+  the two theses and the three places the new-team-member analogy breaks,
+  since the whole design follows from those. Two things that were buried are
+  now sections of their own: how the system learns (a second failure of a kind
+  is a pattern, answered with mechanism; project-agnostic lessons flow back to
+  the template) and how to start small, in three levels a reader can pick
+  between by the shape of their pain. The front-page name is **Agentic
+  Development Kit**; "scaffold" keeps its narrower job of naming what gets
+  installed into a repository (#62).
 - The kit's guard tests stay home. An adopter onboarding an existing project
   spent over an hour, roughly thirty minutes of it inside `run-tests.sh` —
   investigating seven Windows failures in tests they had not touched, for


### PR DESCRIPTION
Closes #62

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/62#issuecomment-5296230672

## What

The README's first line called this "an **AI-agent development lifecycle**" — which reads as a kit for *building* AI agents, the reverse of the truth. Thirty lines of repository wiring, design premises and execution plane followed, without naming one problem any of it solves.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Problem before mechanism; **Agentic Development** defined as a layer over the reader's existing process | New opening: the three pains, then "a layer of practice laid over the process you already run. Waterfall, Scrum, Kanban — it replaces none of them … What changed is *who does the work*" |
| No "kit for developing AI agents" reading survives | `grep -i "AI-agent development\|agent development lifecycle"` → no matches |
| Two theses and the three breaks, in that order | `## Two theses`: new team member → loses its memory every morning / multiplies faster than you can watch / probation never ends → "conversation evaporates; only what lands persists" → the three disciplines |
| Learning loops get their own section | `## The system learns` — `retro` ("a second failure of a kind is a pattern … you are talking to a colleague who forgets every morning") and upstreaming to the template |
| Start-where-you-are with three levels and a way to self-diagnose | `## Start where you are` — L1 record-before-report, L2 one delegated task, L3 full operation, plus "you can tell which step you are on by the shape of the pain" |
| H1 is `Agentic Development Kit` | Line 6 |
| Facts below the opening preserved; naming reconciled | Lifecycle table, repository map, conventions, getting started, lineage, feedback and origin note untouched. Two prose uses of "scaffold" as the product's *name* changed ("the kit is carrying your project"; "tune the installed scaffold to the project"); the ~18 uses that name **the thing installed into a repository** — paths, installer flags, `scaffold-version`, `scaffold-self-check` — are correct and kept |
| Guards | check-md-links OK; check-copilot-surface OK; check-changelog-refs OK |

## What moved rather than went

The Copilot-native execution plane, "generic by design", and the **Three Merges** are all true and load-bearing, so they are kept — under `## How it is put together`, after the reader knows what the kit is for. Nothing below the opening lost a fact.

## Note

The framing is the editor's own, from the methodology chapter this kit implements: the three pains, the two theses, the three breaks, the three disciplines, retro and upstream, and the adoption stairs. The README had been written from the inside out; this puts it back the other way round.
