### PR TITLE
Make the roadmap procedure executable

### DIFF
--- a/.github/prompts/breakdown-epic.prompt.md
+++ b/.github/prompts/breakdown-epic.prompt.md
@@ -13,29 +13,36 @@ Epic issue number: ${input:epicNumber}
    references — many Epics cite few or none. Flag contradictions before
    planning; a missing agreement is not a blocker, so put the needed facts
    directly into the Task issue bodies.
-2. Decompose **only the phase that is about to start** into Task issues.
+2. **Roadmap board:** before decomposing, look for `<repo> roadmap` in
+   `gh project list --owner <owner>`. If absent, search all `type:epic`
+   issues (open and closed) for a comment beginning `Roadmap board: declined`.
+   Only when no marker exists, ask my consent once to run
+   `.github/scripts/setup-project.sh init`; on no, post that exact marker on
+   this Epic. A decline never blocks decomposition and is never asked again.
+   When the board exists, backfill **every open `type:epic` issue** with
+   `setup-project.sh add --project <number> --issue <n>` — onboarding created
+   the sibling Epics before this first decomposition.
+3. Decompose **only the phase that is about to start** into Task issues.
    Draft each brief per `.github/ISSUE_TEMPLATE/ai-task.yml`: Objective,
    Context & references (agreements if any, facts the agent needs),
    Acceptance criteria, Out of scope,
    File ownership, Verification, Routing.
-3. Check the partition: parallel-intended tasks must have disjoint
+4. Check the partition: parallel-intended tasks must have disjoint
    File-ownership paths; overlaps get `blocked-by` edges instead.
-4. Show me the proposed task list (title, exec label, dependencies, ownership)
+5. Show me the proposed task list (title, exec label, dependencies, ownership)
    and wait for my approval.
-5. On approval, create the issues with
+6. On approval, create the issues with
    `.github/skills/plan-management/scripts/new-task.sh` (or the equivalent
    `gh issue create --parent` / `gh issue edit --add-blocked-by` calls) and
-   add `ai:ready` only to complete briefs.
-6. **Roadmap board:** if the board is missing (repo Projects tab, or
-   `gh project list --owner <owner>`), ask my consent once to run
-   `.github/scripts/setup-project.sh init`; on yes, set the created Tasks'
-   schedule spans with `setup-project.sh dates` where dates are known.
-   Never block decomposition on this: a decline is simply noted, and a
-   missing `project` scope is reported with `gh auth refresh -s project`.
-7. Update the Epic body's state line: replace the onboarding draft marker
+   add `ai:ready` only to complete briefs. When the board exists, add every
+   created Task with `setup-project.sh add`; a missing `project` scope is
+   reported with `gh auth refresh -s project`, never treated as a blocker.
+7. Set schedule spans with `setup-project.sh dates` only where real dates are
+   known. Dates are evidence, not a condition for appearing on the board.
+8. Update the Epic body's state line: replace the onboarding draft marker
    ("Draft from onboarding — … nothing is decomposed until you approve.")
    with one line naming the phase just decomposed and today's date. An Epic
    that never carried the marker simply gains the line. Rewriting it each
    round keeps it true — rolling-wave decomposes the same Epic repeatedly.
-8. Post one summary comment on the Epic listing what was created and why,
+9. Post one summary comment on the Epic listing what was created and why,
    including the board outcome (URL, declined, or blocked).

--- a/.github/scripts/setup-project.sh
+++ b/.github/scripts/setup-project.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# setup-project.sh — bootstrap a GitHub Projects (v2) roadmap board and set
-# item dates, so Task/Epic issues can be visualized on a Projects roadmap
-# view with start/target spans.
+# setup-project.sh — bootstrap a GitHub Projects (v2) roadmap board, add
+# Task/Epic issues, and set dates only when real schedule spans exist.
 #
 # Idempotent: `init` reuses an open project with the same title, skips
-# date fields that already exist, and re-links safely; `dates` reuses the
-# project item when the issue is already on the board.
+# date fields that already exist, and re-links safely; `add` and `dates`
+# reuse the project item when the issue is already on the board.
 #
 # Usage:
 #   setup-project.sh init  [--owner <login>] [--title <title>] [-R owner/repo]
+#   setup-project.sh add   --project <number> --issue <n>
+#                          [--owner <login>] [-R owner/repo]
 #   setup-project.sh dates --project <number> --issue <n>
 #                          --start YYYY-MM-DD --target YYYY-MM-DD
 #                          [--owner <login>] [-R owner/repo]
@@ -23,6 +24,8 @@
 #          URL. Re-running is a no-op. Projects v2 boards are always
 #          user/org-owned (repo-owned boards no longer exist); the repo
 #          link makes the board show up in the repository's Projects tab.
+#   add    Add issue <n> to project <number> without inventing dates. Also
+#          sets `Kind` from `type:epic` / `type:task` when available.
 #   dates  Add issue <n> to project <number> (reusing the item when already
 #          present) and set both date fields. Dates must be YYYY-MM-DD; a
 #          target date earlier than the start date is rejected. Also sets
@@ -33,8 +36,8 @@
 #   --owner <login>          Project owner login (user or org). Default: the
 #                            owner of the target repository.
 #   --title <title>          init: board title. Default: "<repo> roadmap".
-#   --project <number>       dates: project number (printed by init).
-#   --issue <n>              dates: issue number to schedule.
+#   --project <number>       add/dates: project number (printed by init).
+#   --issue <n>              add/dates: issue number to add or schedule.
 #   --start <YYYY-MM-DD>     dates: start date.
 #   --target <YYYY-MM-DD>    dates: target date (not earlier than start).
 #   -R, --repo <owner/repo>  Target repository. Default: the repository the
@@ -120,6 +123,64 @@ option_id() {
     | jq -r --arg name "$3" --arg opt "$4" \
         '[.fields[] | select(.name == $name) | .options[]?
           | select(.name == $opt) | .id] | first // empty'
+}
+
+# Shared context for `add` and `dates`. Bash 3.2 has no namerefs, so these
+# values are deliberately scoped with a prefix rather than returned through
+# caller-owned variables.
+PROJECT_NODE_ID=""
+PROJECT_ITEM_ID=""
+PROJECT_ISSUE_URL=""
+PROJECT_ISSUE_LABELS=""
+
+load_project_issue() {
+  local project="$1" owner="$2" issue="$3" issue_json
+  # Resolving the URL via the API also fails fast when the issue is missing.
+  issue_json="$(gh issue view "$issue" --repo "$REPO" --json url,labels)"
+  PROJECT_ISSUE_URL="$(jq -r '.url' <<<"$issue_json")"
+  PROJECT_ISSUE_LABELS="$(jq -r '.labels[].name' <<<"$issue_json")"
+  PROJECT_NODE_ID="$(gh project view "$project" --owner "$owner" \
+    --format json --jq '.id')"
+}
+
+ensure_project_item() {
+  local project="$1" owner="$2"
+  # item-add is idempotent: when the issue is already on the board it
+  # returns the existing item's ID instead of failing or duplicating.
+  PROJECT_ITEM_ID="$(gh project item-add "$project" --owner "$owner" \
+    --url "$PROJECT_ISSUE_URL" --format json --jq '.id')"
+}
+
+apply_kind() {
+  local project="$1" owner="$2" issue="$3" kind=""
+  if printf '%s\n' "$PROJECT_ISSUE_LABELS" | grep -Fxq "type:epic"; then
+    kind="Epic"
+  elif printf '%s\n' "$PROJECT_ISSUE_LABELS" | grep -Fxq "type:task"; then
+    kind="Task"
+  fi
+  if [[ -z "$kind" ]]; then
+    echo "Note: issue #$issue has neither 'type:epic' nor 'type:task' label;" \
+      "leaving 'Kind' unset."
+    return 0
+  fi
+
+  # Older boards (init run before the Kind field existed) stay usable:
+  # setting Kind is best-effort, with a pointer to re-run init.
+  local kind_field_id kind_option_id
+  kind_field_id="$(field_id "$project" "$owner" "Kind")"
+  if [[ -z "$kind_field_id" ]]; then
+    echo "Note: project #$project has no 'Kind' field;" \
+      "re-run 'setup-project.sh init' to add it."
+    return 0
+  fi
+  kind_option_id="$(option_id "$project" "$owner" "Kind" "$kind")"
+  [[ -n "$kind_option_id" ]] \
+    || fail "field 'Kind' on project #$project has no '$kind' option"
+
+  gh project item-edit --id "$PROJECT_ITEM_ID" \
+    --project-id "$PROJECT_NODE_ID" --field-id "$kind_field_id" \
+    --single-select-option-id "$kind_option_id" >/dev/null
+  echo "Set Kind = $kind for issue #$issue."
 }
 
 cmd_init() {
@@ -276,6 +337,47 @@ reuse it and complete the fields and the repository link"
   echo "grouping or date fields."
 }
 
+cmd_add() {
+  local owner="" project="" issue=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --owner)
+        [[ -n "${2:-}" ]] || usage_error "--owner requires a login argument"
+        owner="$2"; shift 2 ;;
+      --project)
+        [[ -n "${2:-}" ]] || usage_error "--project requires a project number"
+        project="$2"; shift 2 ;;
+      --issue)
+        [[ -n "${2:-}" ]] || usage_error "--issue requires an issue number"
+        issue="$2"; shift 2 ;;
+      -R|--repo)
+        [[ -n "${2:-}" ]] || usage_error "$1 requires an owner/repo argument"
+        REPO="$2"; shift 2 ;;
+      -h|--help)
+        usage; exit 0 ;;
+      *)
+        usage_error "unknown argument for add: $1" ;;
+    esac
+  done
+  [[ -n "$project" && -n "$issue" ]] \
+    || usage_error "add requires --project and --issue"
+
+  local num_re='^[0-9]+$'
+  [[ "$project" =~ $num_re ]] \
+    || usage_error "--project must be a number, got: $project"
+  [[ "$issue" =~ $num_re ]] \
+    || usage_error "--issue must be a number, got: $issue"
+
+  require_tools
+  resolve_repo
+  [[ -n "$owner" ]] || owner="$REPO_OWNER"
+
+  load_project_issue "$project" "$owner" "$issue"
+  ensure_project_item "$project" "$owner"
+  echo "Added/reused issue #$issue ($REPO) on project #$project."
+  apply_kind "$project" "$owner" "$issue"
+}
+
 cmd_dates() {
   local owner="" project="" issue="" start="" target=""
   while [[ $# -gt 0 ]]; do
@@ -322,66 +424,31 @@ cmd_dates() {
   resolve_repo
   [[ -n "$owner" ]] || owner="$REPO_OWNER"
 
-  # Resolving the URL via the API also fails fast when the issue is missing.
-  local issue_json issue_url issue_labels project_id start_field_id target_field_id item_id
-  issue_json="$(gh issue view "$issue" --repo "$REPO" --json url,labels)"
-  issue_url="$(jq -r '.url' <<<"$issue_json")"
-  issue_labels="$(jq -r '.labels[].name' <<<"$issue_json")"
-  project_id="$(gh project view "$project" --owner "$owner" --format json --jq '.id')"
+  local start_field_id target_field_id
+  load_project_issue "$project" "$owner" "$issue"
   start_field_id="$(field_id "$project" "$owner" "Start date")"
   target_field_id="$(field_id "$project" "$owner" "Target date")"
   [[ -n "$start_field_id" && -n "$target_field_id" ]] \
     || fail "project #$project has no 'Start date'/'Target date' fields — run 'setup-project.sh init' first"
 
-  # item-add is idempotent: when the issue is already on the board it
-  # returns the existing item's ID instead of failing or duplicating.
-  item_id="$(gh project item-add "$project" --owner "$owner" \
-    --url "$issue_url" --format json --jq '.id')"
+  ensure_project_item "$project" "$owner"
 
-  gh project item-edit --id "$item_id" --project-id "$project_id" \
+  gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_NODE_ID" \
     --field-id "$start_field_id" --date "$start" >/dev/null
-  gh project item-edit --id "$item_id" --project-id "$project_id" \
+  gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_NODE_ID" \
     --field-id "$target_field_id" --date "$target" >/dev/null
 
   echo "Scheduled issue #$issue ($REPO) on project #$project:" \
     "Start date $start, Target date $target."
 
-  # Derive Kind from the scaffold's canonical labels (setup-labels.sh).
-  local kind=""
-  if printf '%s\n' "$issue_labels" | grep -Fxq "type:epic"; then
-    kind="Epic"
-  elif printf '%s\n' "$issue_labels" | grep -Fxq "type:task"; then
-    kind="Task"
-  fi
-  if [[ -z "$kind" ]]; then
-    echo "Note: issue #$issue has neither 'type:epic' nor 'type:task' label;" \
-      "leaving 'Kind' unset."
-    return 0
-  fi
-
-  # Older boards (init run before the Kind field existed) stay usable:
-  # setting Kind is best-effort, with a pointer to re-run init.
-  local kind_field_id kind_option_id
-  kind_field_id="$(field_id "$project" "$owner" "Kind")"
-  if [[ -z "$kind_field_id" ]]; then
-    echo "Note: project #$project has no 'Kind' field;" \
-      "re-run 'setup-project.sh init' to add it."
-    return 0
-  fi
-  kind_option_id="$(option_id "$project" "$owner" "Kind" "$kind")"
-  [[ -n "$kind_option_id" ]] \
-    || fail "field 'Kind' on project #$project has no '$kind' option"
-
-  gh project item-edit --id "$item_id" --project-id "$project_id" \
-    --field-id "$kind_field_id" --single-select-option-id "$kind_option_id" \
-    >/dev/null
-  echo "Set Kind = $kind for issue #$issue."
+  apply_kind "$project" "$owner" "$issue"
 }
 
 case "${1:-}" in
   init)      shift; cmd_init "$@" ;;
+  add)       shift; cmd_add "$@" ;;
   dates)     shift; cmd_dates "$@" ;;
   -h|--help) usage; exit 0 ;;
-  "")        usage_error "missing subcommand (init or dates)" ;;
+  "")        usage_error "missing subcommand (init, add or dates)" ;;
   *)         usage_error "unknown subcommand: $1" ;;
 esac

--- a/.github/scripts/tests/test-setup-project.sh
+++ b/.github/scripts/tests/test-setup-project.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # test-setup-project.sh — regression tests for .github/scripts/setup-project.sh.
 #
-# Scope here: the working views `init` ensures on the roadmap board. The
-# script talks to GitHub through `gh project …` and `gh api graphql`; the
-# shim below answers both from per-case fixtures, so no network, no auth and
-# no Projects permissions are needed.
+# Scope here: the working views `init` ensures and the item paths shared by
+# `add` / `dates`. The script talks to GitHub through `gh project …`,
+# `gh issue …`, and `gh api graphql`; the shim below answers all three, so no
+# network, auth, or Projects permissions are needed.
 #
 # Why views are worth a guard: `createProjectV2View` accepts only a name and
 # a layout, and the board is created once per adopting repository, so a
@@ -32,8 +32,24 @@ case "${1:-}" in
   project)
     case "${2:-}" in
       list)  printf '{"projects":[{"number":6,"title":"r roadmap","closed":false}]}\n' ;;
-      view)  printf '{"id":"PVT_test","url":"https://github.com/orgs/o/projects/6"}\n' ;;
-      field-list) printf '{"fields":[{"name":"Start date"},{"name":"Target date"},{"name":"Kind"}]}\n' ;;
+      view)
+        case "$*" in
+          *".url"*) printf 'https://github.com/orgs/o/projects/6\n' ;;
+          *)        printf 'PVT_test\n' ;;
+        esac
+        ;;
+      field-list)
+        printf '%s\n' '{"fields":[{"id":"F_START","name":"Start date"},{"id":"F_TARGET","name":"Target date"},{"id":"F_KIND","name":"Kind","options":[{"id":"O_EPIC","name":"Epic"},{"id":"O_TASK","name":"Task"}]}]}'
+        ;;
+      item-add)
+        printf '%s\n' "$*" >> "$ITEM_ADD_LOG"
+        # The real command carries `--jq .id`, so emit the projected value,
+        # not the pre-jq JSON object.
+        printf 'PVTI_existing\n'
+        ;;
+      item-edit)
+        printf '%s\n' "$*" >> "$ITEM_EDIT_LOG"
+        ;;
       link)  : ;;
       *)     : ;;
     esac
@@ -62,6 +78,10 @@ case "${1:-}" in
     esac
     ;;
   repo) printf 'o/r\n' ;;
+  issue)
+    printf '{"url":"https://github.com/o/r/issues/%s","labels":%s}\n' \
+      "${3:-42}" "${ISSUE_LABELS_JSON:-[]}"
+    ;;
   *) : ;;
 esac
 SHIM
@@ -72,6 +92,17 @@ export PATH
 run_init() {
   VIEWS_FIXTURE="$1" CREATED_LOG="$2" CREATE_FAILS="${3:-0}" AUTHED="${AUTHED:-1}" \
     bash "$SCRIPT" init --owner o -R o/r 2>&1
+}
+
+run_add() {
+  ITEM_ADD_LOG="$1" ITEM_EDIT_LOG="$2" ISSUE_LABELS_JSON="$3" \
+    bash "$SCRIPT" add --owner o --project 6 --issue 42 -R o/r 2>&1
+}
+
+run_dates() {
+  ITEM_ADD_LOG="$1" ITEM_EDIT_LOG="$2" ISSUE_LABELS_JSON="$3" \
+    bash "$SCRIPT" dates --owner o --project 6 --issue 42 \
+      --start 2026-08-01 --target 2026-08-05 -R o/r 2>&1
 }
 
 # --- an empty board gains all three views ---------------------------------
@@ -167,6 +198,66 @@ if [ ! -s "$WORK/created-auth.log" ] \
 else
   t_fail "the preflight stops before touching the project"
   printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+
+# --- add places an undated Epic and sets Kind ------------------------------
+: > "$WORK/item-add-epic.log"
+: > "$WORK/item-edit-epic.log"
+out=$(run_add "$WORK/item-add-epic.log" "$WORK/item-edit-epic.log" \
+  '[{"name":"type:epic"}]')
+rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q 'item-add.*--url https://github.com/o/r/issues/42' \
+      "$WORK/item-add-epic.log" \
+   && grep -q -- '--single-select-option-id O_EPIC' \
+      "$WORK/item-edit-epic.log"; then
+  t_ok "add places an undated Epic and sets Kind"
+else
+  t_fail "add places an undated Epic and sets Kind (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+if grep -q -- '--date' "$WORK/item-edit-epic.log"; then
+  t_fail "add does not write dates"
+else
+  t_ok "add does not write dates"
+fi
+
+# --- add derives Task Kind through the same helper -------------------------
+: > "$WORK/item-add-task.log"
+: > "$WORK/item-edit-task.log"
+run_add "$WORK/item-add-task.log" "$WORK/item-edit-task.log" \
+  '[{"name":"type:task"}]' >/dev/null
+if grep -q -- '--single-select-option-id O_TASK' "$WORK/item-edit-task.log"; then
+  t_ok "add derives Task Kind from the issue label"
+else
+  t_fail "add derives Task Kind from the issue label"
+fi
+
+# --- re-adding reuses the item ID returned by GitHub -----------------------
+: > "$WORK/item-add-twice.log"
+: > "$WORK/item-edit-twice.log"
+run_add "$WORK/item-add-twice.log" "$WORK/item-edit-twice.log" \
+  '[{"name":"type:epic"}]' >/dev/null
+run_add "$WORK/item-add-twice.log" "$WORK/item-edit-twice.log" \
+  '[{"name":"type:epic"}]' >/dev/null
+if [ "$(grep -c -- '--id PVTI_existing' "$WORK/item-edit-twice.log")" -eq 2 ]; then
+  t_ok "re-adding reuses the existing project item ID"
+else
+  t_fail "re-adding reuses the existing project item ID"
+fi
+
+# --- dates still writes two dates and applies Kind -------------------------
+: > "$WORK/item-add-dates.log"
+: > "$WORK/item-edit-dates.log"
+run_dates "$WORK/item-add-dates.log" "$WORK/item-edit-dates.log" \
+  '[{"name":"type:task"}]' >/dev/null
+date_edits=$(grep -c -- '--date 2026-08-' "$WORK/item-edit-dates.log")
+if [ "$date_edits" -eq 2 ] \
+   && grep -q -- '--single-select-option-id O_TASK' \
+      "$WORK/item-edit-dates.log"; then
+  t_ok "dates writes the real span and shares Kind handling"
+else
+  t_fail "dates writes the real span and shares Kind handling"
 fi
 
 t_summary

--- a/.github/skills/plan-management/SKILL.md
+++ b/.github/skills/plan-management/SKILL.md
@@ -35,10 +35,26 @@ this.
 
 ## Rolling-wave decomposition
 
+0. **Own the roadmap decision here, before the first decomposition.** Look for
+   `<repo> roadmap` with `gh project list --owner <owner>`. If it is absent
+   and no Epic carries a comment beginning `Roadmap board: declined`, ask one
+   consent question; on yes run `.github/scripts/setup-project.sh init`, on no
+   post that exact marker on the current Epic and continue. The marker is a
+   repository-wide decision: later decompositions search all `type:epic`
+   issues (open and closed), so a human is not asked again after the first
+   decline. A declined or unavailable board never blocks decomposition. Once
+   the board exists, backfill every open `type:epic` issue returned by
+   `gh issue list --label type:epic --state open` with `setup-project.sh add`;
+   onboarding created those sibling Epics before this first decomposition, so
+   waiting for future creation would leave them invisible again.
 1. Create Epics for the whole outline up front — cheap, low detail, gives the
    "what comes next" visibility agents need for preparation. One Epic per
    phase, all siblings: the graph is two levels, so an Epic is never a
-   sub-issue of another Epic. Order them with `blocked-by`.
+   sub-issue of another Epic. Order them with `blocked-by`. When the roadmap
+   exists, add every Epic as it is created with
+   `.github/scripts/setup-project.sh add --project <number> --issue <n>` —
+   visibility must not wait for dates that rolling-wave planning deliberately
+   has not invented.
 2. Decompose an Epic into Task sub-issues only when its phase is about to
    start (or when the frontier is nearly empty). Detail decays; write it late.
 3. Every Task must clear the planner quality bar
@@ -46,7 +62,9 @@ this.
    see `.github/agents/planner.agent.md`). Only then add `ai:ready`.
    Criteria that can only be met after the merge (a tag, a release, a
    deploy check) must say so in the work order — they commit the PR to
-   `Refs #<n>` and a manual close (AGENTS.md §4).
+   `Refs #<n>` and a manual close (AGENTS.md §4). When the roadmap exists,
+   add each Task as it is created too; its visibility must not depend on
+   whether scheduling dates are known.
 4. Partition for parallelism: tasks meant to run concurrently must have
    disjoint **File ownership** path sets. If two tasks need the same paths,
    add a `blocked-by` edge between them — serialization by dependency beats
@@ -60,6 +78,9 @@ this.
    is the one issue body an executing session may edit: AGENTS.md §5 binds
    an agent to its own **Task** issue, and the Epic is the plan it works
    from, not the work order it executes.
+6. When the round has real dates, schedule its Epic and Tasks with
+   `.github/scripts/setup-project.sh dates`. Dates are evidence, not board
+   admission tickets: never invent them to make an issue visible.
 
 ## The frontier
 
@@ -105,11 +126,9 @@ gh issue list --label "ai:ready" --state open --json number,title,labels
 
 Optional: visualize Epics and Tasks as spans on a Projects v2 roadmap. The
 board stays a *view* of the issue graph — fields are derived from issues,
-never the reverse (see the Portfolio view row in the Data model). Creation
-has an owner: the first decomposition checks for the
-board and, when absent, offers `init` with one consent question — declining
-never blocks decomposition, and the board can still be attached manually
-any time.
+never the reverse (see the Portfolio view row in the Data model). Rolling-wave
+steps 0, 1, and 6 own *when* the board is offered, populated, and scheduled;
+this section owns only *how* those commands work.
 
 Bootstrap the board once per repository (idempotent: reuses the same-title
 project, skips existing fields, re-links safely). `init` creates the DATE
@@ -121,6 +140,13 @@ board:
 .github/scripts/setup-project.sh init      # creates "<repo> roadmap", owner = repo owner
 ```
 
+Put an Epic or Task on the board before it has dates (idempotent: reuses the
+existing item). The call sets `Kind` from the issue's canonical label:
+
+```bash
+.github/scripts/setup-project.sh add --project <number> --issue <n>
+```
+
 Projects v2 boards cannot be repo-owned — they always belong to a user or
 org, so the board URL is `github.com/orgs/<owner>/projects/<n>` (or
 `/users/...`). That is normal. `init` links the board to the repository,
@@ -128,10 +154,10 @@ which makes it appear in the repo's **Projects** tab
 (`https://github.com/<owner>/<repo>/projects`) — look for it there. Pass
 `--owner <login>` only to place the board under a different user/org.
 
-When the board exists, set an issue's schedule span when the Task is
-created during decomposition, and update it whenever replanning moves the
-schedule (re-running replaces both dates on the existing item). The same
-call sets `Kind` automatically
+When the board exists, set an issue's schedule span only when real dates are
+known, and update it whenever replanning moves the schedule (re-running
+replaces both dates on the existing item). The same call sets `Kind`
+automatically
 from the issue's labels — `type:epic` → Epic, `type:task` → Task:
 
 ```bash

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,16 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Roadmap creation and population moved from unreachable prose into the
+  rolling-wave procedure that agents actually execute. An adopter created
+  nine Epics but saw only one on the board: the board check sat sixty lines
+  below the numbered decomposition steps, while `setup-project.sh` could add
+  an issue only through `dates`, which requires a schedule that future Epics
+  deliberately do not have yet. Step 0 now owns the one consent-gated board
+  offer, step 1 adds every Epic immediately, and step 6 schedules only issues
+  with real dates. New idempotent `add` places an issue and sets `Kind`
+  without touching date fields; `add` and `dates` share their item and Kind
+  logic so the two paths cannot drift (#54).
 - The README says what the kit is for before it says how it is built. Its
   opening called this "an AI-agent development lifecycle" — which reads as a
   kit for *building* AI agents, the opposite of the truth — and then spent


### PR DESCRIPTION
Closes #54

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/54#issuecomment-5303311778

## What

An adopter created nine sibling Epics and saw one on the roadmap. Two independent gaps caused it:

1. The board offer lived ~60 lines below the numbered decomposition procedure, so an agent could complete the procedure without ever reaching the rule.
2. `setup-project.sh` admitted issues only through `dates`, which requires a schedule that future Epics deliberately do not have yet.

The procedure now executes the rule, and the script can add an issue without inventing dates.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| First decomposition owns the board decision | Rolling-wave step 0 checks for `<repo> roadmap`, asks once only when no durable decline marker exists, initializes on consent, and never blocks decomposition on decline/unavailability |
| Consent is truly one-time | A decline is recorded as an exact `Roadmap board: declined` comment. Later decompositions search all `type:epic` issues, open and closed, before asking |
| Every Epic is visible | Step 0 backfills every open `type:epic` issue created during onboarding; step 1 adds future Epics immediately with `setup-project.sh add` |
| Tasks do not wait for dates either | Task-creation step adds each Task when a board exists; scheduling is a separate step after real dates exist |
| Undated add command | `setup-project.sh add --project <number> --issue <n>` adds/reuses the item and sets `Kind`, with no date writes |
| `add` and `dates` cannot drift | Shared `load_project_issue`, `ensure_project_item`, and `apply_kind` helpers; only `dates` resolves and writes date fields |
| Concrete entry point agrees with the skill | `breakdown-epic.prompt.md` now follows board check/backfill → Task creation/add → real-date scheduling, replacing its old dates-only postscript |
| Tests | `test-setup-project.sh`: 13/13 — views, auth preflight, undated Epic + Kind, no dates, Task Kind, repeated add, and dates + shared Kind |
| Full regression wall | `run-tests.sh`: all 19 guard suites passed |
| Static/documentation walls | shellcheck `-S style`, `check-copilot-surface`, `check-md-links`, `check-escalation-wording`, `check-changelog-refs`, and `git diff --check` all pass |

## Deviations

- The issue links a downstream reference implementation, but that repository currently returns "repository not found" to this session. The detailed design preserved in the issue body was used as the durable source instead.
- File ownership was implicit because #54 predates the current Task template. The issue explicitly names the skill, script, and tests; the concrete `breakdown-epic` prompt was added after implementation revealed it still encoded the old contradictory order. The plan expansion was recorded before that file was changed.
- No live Project item was mutated during verification: this repository currently has no `<repo> roadmap`, and creating one is consent-gated by the very behavior under test. Read-only `gh project list` and real `gh issue view --json url,labels` confirmed the live CLI response shapes; the offline shim verifies writes deterministically.

## Why dates stay separate

Dates are evidence, not board admission tickets. Rolling-wave planning intentionally keeps future phases coarse; assigning dates merely to make an Epic visible would put fiction on the board and reverse the issue graph's authority.
