### PR TITLE
Stop offline ritual tests from sleeping for GitHub

### DIFF
--- a/.github/scripts/check-task-ritual.sh
+++ b/.github/scripts/check-task-ritual.sh
@@ -95,15 +95,19 @@ command -v gh >/dev/null 2>&1 || { echo "error: gh CLI not found" >&2; exit 1; }
 
 # GitHub occasionally answers with a transient HTML 5xx page ("invalid
 # character '<'"); a deterministic wall must not flake on that, so every API
-# read gets three attempts with a short pause.
+# read gets three attempts with a short pause. Offline fixtures set the pause
+# to zero through RITUAL_API_RETRY_DELAY; production keeps the two-second
+# default. The attempt count is never configurable.
 api() {
-  local attempt out
+  local attempt out delay="${RITUAL_API_RETRY_DELAY:-2}"
   for attempt in 1 2 3; do
     if out=$(gh api "$@" 2>&1); then
       printf '%s\n' "$out"
       return 0
     fi
-    [[ $attempt -lt 3 ]] && sleep 2
+    if [[ $attempt -lt 3 && "$delay" != "0" ]]; then
+      sleep "$delay"
+    fi
   done
   printf '%s\n' "$out" >&2
   return 1

--- a/.github/scripts/tests/lib.sh
+++ b/.github/scripts/tests/lib.sh
@@ -9,6 +9,13 @@
 TESTS_RUN=0
 TESTS_FAILED=0
 
+# Negative ritual fixtures deliberately make API reads fail. Production waits
+# two seconds before retrying a transient GitHub error; an offline JSON
+# fixture will not recover with time, so tests retain all three attempts and
+# remove only the pause. Respect an explicit caller value for retry-contract
+# tests.
+export RITUAL_API_RETRY_DELAY="${RITUAL_API_RETRY_DELAY:-0}"
+
 t_ok() {
   TESTS_RUN=$((TESTS_RUN + 1))
   echo "ok - $1"

--- a/.github/scripts/tests/test-task-ritual.sh
+++ b/.github/scripts/tests/test-task-ritual.sh
@@ -48,6 +48,54 @@ ISSUE_TASK='{"labels":[{"name":"type:task"},{"name":"ai:ready"},{"name":"exec:ap
 PLAN_COMMENT_12='{"issue_url":"https://api.github.com/repos/o/r/issues/12","body":"## Plan\\n\\n1. Do the thing."}'
 PLAN_COMMENT_34='{"issue_url":"https://api.github.com/repos/o/r/issues/34","body":"## Plan\\n\\n1. Do the thing."}'
 
+# --- production retry contract --------------------------------------------
+# The first two gh calls fail; the third and every later call delegate to the
+# normal fixture shim. A sleep shim records the requested delay without
+# waiting, so this case proves both production defaults behaviorally:
+# three attempts, with two two-second pauses. The ordinary fixture suite
+# keeps RITUAL_API_RETRY_DELAY=0 through lib.sh.
+new_case "$HUMAN_PR_BODY" "[$CLAIM, $PLAN_HEADING]"
+# Keep later reads successful so the only retries observed are the two
+# transient failures injected by retry-bin/gh below.
+printf '%s\n' '{"sha":"base_has_agents"}' > "$CASE/contents-agents.json"
+mkdir -p "$WORK/retry-bin"
+cat > "$WORK/retry-bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$RETRY_LOG"
+count=$(wc -l < "$RETRY_LOG" | tr -d ' ')
+if [ "$count" -le 2 ]; then
+  exit 1
+fi
+exec "$REAL_GH_SHIM" "$@"
+SHIM
+cat > "$WORK/retry-bin/sleep" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$SLEEP_LOG"
+SHIM
+chmod +x "$WORK/retry-bin/gh" "$WORK/retry-bin/sleep"
+: > "$WORK/retry-calls.log"
+: > "$WORK/retry-sleeps.log"
+rc=0
+out=$(env -u RITUAL_API_RETRY_DELAY \
+  PATH="$WORK/retry-bin:$PATH" \
+  GH_FIXTURES="$CASE" \
+  REAL_GH_SHIM="$WORK/bin/gh" \
+  RETRY_LOG="$WORK/retry-calls.log" \
+  SLEEP_LOG="$WORK/retry-sleeps.log" \
+  bash "$GUARD" 12 2>&1) || rc=$?
+first_three_unique=$(head -n 3 "$WORK/retry-calls.log" | sort -u | wc -l | tr -d ' ')
+sleep_twos=$(grep -c '^2$' "$WORK/retry-sleeps.log")
+if [ "$rc" -eq 0 ] \
+   && [ "$first_three_unique" -eq 1 ] \
+   && [ "$sleep_twos" -eq 2 ]; then
+  t_ok "production retry remains three attempts with two-second pauses"
+else
+  t_fail "production retry remains three attempts with two-second pauses (rc=$rc)"
+  printf '%s\n' "$out" | sed 's/^/    # /'
+fi
+
 # --- allowlisted bot PRs are exempt -------------------------------------------
 new_case '{"user":{"login":"dependabot[bot]","type":"Bot"},"body":"Bumps actions/checkout."}' '[]'
 GH_FIXTURES="$CASE" expect_rc 0 "allowlisted bot PR is exempt" bash "$GUARD" 12

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,14 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Guard regression tests no longer spend six minutes sleeping through
+  failures they deliberately created. Five ritual suites consumed 344 of the
+  regression step's 361 seconds because every missing comment or broken link
+  paid the production GitHub retry backoff: three attempts with two-second
+  pauses. Production keeps that exact contract; offline tests set only the
+  pause to zero, keeping every attempt and assertion. A behavioral fixture
+  makes the first two API calls fail, the third succeed, and shims `sleep` to
+  prove the default remains two seconds without waiting for it (#66).
 - Roadmap creation and population moved from unreachable prose into the
   rolling-wave procedure that agents actually execute. An adopter created
   nine Epics but saw only one on the board: the board check sat sixty lines


### PR DESCRIPTION
Closes #66

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/66#issuecomment-5303450569

## What

`scaffold-self-check` spent 6m01s in guard regression tests and about 6s on every other step combined. The regression cases were not expensive; their **expected failures were paying production network backoff**.

Five ritual suites consumed 344s (~95%): every missing comment or broken link retried three times, sleeping two seconds between attempts. An offline JSON fixture will not recover with time.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Production retry unchanged | `RITUAL_API_RETRY_DELAY` defaults to `2`; attempt count remains the literal `1 2 3` and is not configurable |
| Offline tests retain attempts but skip pauses | `lib.sh` exports delay `0` unless explicitly overridden; every existing test and assertion remains |
| Direct individual tests are fast | Shared `lib.sh` applies to direct execution, not only `run-tests.sh` |
| Behavioral retry contract | New case: first two `gh` calls fail, third delegates to normal fixtures; a `sleep` shim records two requests for `2`. Test passes only if the guard both retries three times and keeps the production default |
| Full suite under 60s | **18.8s**, down from 361s (94.8% reduction); all 19 suites pass |
| No tests weakened | 19 test files before and after; new retry case raises `test-task-ritual` from 13 to 14 cases |
| Static walls | shellcheck `-S style`, check-copilot-surface, check-changelog-refs, check-md-links, check-escalation-wording, and `git diff --check` all pass |

### Ritual suite timings

| Suite | Before | After |
|---|---:|---:|
| adoption | 16.2s | 0.51s |
| chronology | 40.6s | 0.93s |
| dispatch | 129.8s | 2.84s |
| linkage | 76.9s | 1.49s |
| task-ritual | 80.8s | 1.86s |

## Deviations

None. This does not change task-ritual policy; the question of which ritual conditions deserve hard failures remains on #6.
