### PR TITLE
Ask which model builds and which model doubts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,17 @@ execution-plane surface: frontmatter, ceilings, English-only.
         will fail in cloud environments — never use it there.
 -->
 
+## Models
+
+Recorded during onboarding (P2); `auto` means the app decides.
+
+- **Implementation:** `auto`
+- **Review:** `auto`
+
+Dispatch implementation work on the first, layer-3 review on the second
+(`task-routing`, `verification`). When they differ, that is deliberate: a
+reviewer sharing the implementer's blind spot reviews less.
+
 ## Working a Task issue
 
 The Task issue body is your work order: you read it, you never edit it

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -88,8 +88,9 @@ routing first needs it (`exec:ide`), not interviewed up front.
 
 ### P2 — Interview (hand-over only)
 
-The interview covers one topic: **how specification and design material
-reaches the scaffold**. Everything else about the repository is
+The interview covers what the repository cannot answer for itself: **how
+specification and design material reaches the scaffold**, and **which
+models run the work**. Everything else about the repository is
 discovered by P1/P3 or when work first needs it — path restrictions are
 declared per task in File ownership at decomposition time, secrets
 specifics surface when work first touches them (baseline guardrails
@@ -127,6 +128,21 @@ Ask in sequence, second step branching on the first answer:
    landing mechanics (copy vs move vs reference index) in the questions
    or the choices; landing is the P4 seed step, not the adopter's
    problem.)*
+3. **Implementation model.** *"Which model should agents use for
+   implementation work? Type a model name if you have a preference;
+   `auto` is a safe answer and means the app decides."*
+4. **Review model.** *"And for reviewing that work? A different model
+   catches blind spots the implementing one shares. The same answer is
+   fine, and `auto` again means the app decides."*
+
+   These two are here because no later step can ask them: P1 reads
+   manifests, P3 runs commands, and neither can learn a team's
+   preference. Take the answers as typed and **never suggest a model
+   name** — not in the question, not as an example, not as a default.
+   Naming one dates this skill to the month it was written, and the
+   adopter knows today's names better than it does. The reason in the
+   second question is a recommendation, not a rule; two identical
+   answers, or two `auto`s, are complete.
 
 **Close P2 before starting P3** — verification is the long stretch, so
 give the adopter something to review during it:
@@ -205,6 +221,9 @@ unrun command.
   Repo-resident documents are **not** copied into `.github/docs/context/` — they
   stay in place and are read where they live. Do **not**
   write agreements — distillation is a separate, human-gated phase.
+- Record the P2 model answers verbatim in copilot-instructions' **Models**
+  block. Two unanswered questions are two `auto`s, which is a complete
+  answer and not a gap.
 - Do **not** touch `AGENTS.md` (Budget rule; behavior is project-independent).
 
 ### P5 — Prove

--- a/.github/skills/task-routing/SKILL.md
+++ b/.github/skills/task-routing/SKILL.md
@@ -116,6 +116,11 @@ change), but the effort tier is meaningful:
 | `fast` | Mechanical edits, renames, formatting, boilerplate | smaller/faster model |
 | `local` | Sensitive data, offline work | on-device model |
 
+Which model fills a tier is the adopter's answer, recorded in
+copilot-instructions' **Models** block — read it there rather than
+naming one here. Review is dispatched on the review model, which may
+differ from the implementation model on purpose.
+
 ## Role suggestion
 
 Suggest a role when a specialized definition exists in `.github/agents/`

--- a/.github/skills/verification/SKILL.md
+++ b/.github/skills/verification/SKILL.md
@@ -30,7 +30,10 @@ is the cap and the exit, not an invitation to grind until green.
    ship "temporary" suppressions without a linked issue.
 3. **AI review** — Copilot code review and/or the `reviewer` agent, guided by
    `.github/instructions/code-review.instructions.md`. Catches claim/evidence
-   gaps and silent deviations before a human spends attention.
+   gaps and silent deviations before a human spends attention. Run it on the
+   review model recorded in copilot-instructions' **Models** block: a
+   reviewer sharing the implementer's blind spot reviews less, so where the
+   two differ, the difference is the point.
 4. **Human review** — judgment: is this the *right* change? Protected by
    branch ruleset (required PR + required checks + human approval on
    agent-authored PRs).

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,19 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Onboarding asks which model builds and which model doubts. Nothing had ever
+  asked, so every adopter ran on whatever their app defaulted to and no
+  session downstream could know otherwise — and unlike path restrictions or
+  the roadmap board, no later phase can discover it: P1 reads manifests, P3
+  runs commands, and neither learns a team's preference. P2 now asks two
+  free-text questions and P4 records the answers where `task-routing` and
+  `verification` read them. The second question carries its reason in one
+  clause — a reviewer sharing the implementer's blind spot reviews less — as
+  a recommendation, not a rule; two identical answers are complete, and so
+  are two `auto`s. **The scaffold names no model anywhere**: it holds the
+  adopter's answer and no opinion about which models exist this month. The
+  retirement condition ships with the feature (#69), because a question that
+  outlives its usefulness is how an interview gets slowly worse (#68).
 - Guard regression tests no longer spend six minutes sleeping through
   failures they deliberately created. Five ritual suites consumed 344 of the
   regression step's 361 seconds because every missing comment or broken link


### PR DESCRIPTION
Closes #68

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/68#issuecomment-5303727228

## What

Onboarding never asked which model runs the work. Every adopter started on whatever their app defaulted to, and nothing downstream could know otherwise.

Unlike the things P2 deliberately does not ask — path restrictions, secrets, the roadmap board — **no later phase can pick this up**. P1 reads manifests, P3 runs commands; neither learns that a team prefers one model for building and another for review.

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Two free-text questions in P2 | Steps 3 and 4: implementation model, then review model, after the material steps |
| **No model name anywhere** | `git diff -U0 \| grep -iE 'opus\|sonnet\|gpt-5\|claude\|fable\|gemini\|sol\|haiku'` on the added lines → no matches. The skill says so explicitly: "**never suggest a model name** — not in the question, not as an example, not as a default" |
| `auto` is a safe answer in both | Stated in each question, matching P2's existing "Don't know is a safe answer" register |
| The reason appears once, as a recommendation | Second question: "A different model catches blind spots the implementing one shares." Followed by "The same answer is fine" and, in the guidance, "a recommendation, not a rule; two identical answers, or two `auto`s, are complete" |
| P4 records the answers | New P4 bullet writes them verbatim into the **Models** block; "Two unanswered questions are two `auto`s, which is a complete answer and not a gap" |
| Consumers point rather than restate | `task-routing`: "Which model fills a tier is the adopter's answer, recorded in copilot-instructions' **Models** block — read it there rather than naming one here." `verification` layer 3: "Run it on the review model recorded in … **Models**" |
| Costs nothing when unanswered | Both default to `auto` in the shipped block; nothing blocks onboarding |
| Budget | `AGENTS.md` unchanged at 117; `copilot-instructions.md` 117 → 128 (the block plus one line of context); ceilings pass |
| Verification wall | check-copilot-surface OK; run-tests.sh 19 suites green (18.7s); check-md-links, check-changelog-refs, check-escalation-wording OK |

### Why the second question exists

From this repository's own week, both directions in the same day: one model read a six-minute test run as a hang **twice** and never thought to break it down, while a different model measured it and found 95% of the time was fake sleep (#66). The first model then wrote the root-cause analysis in #58 the second had not reached.

Neither is better. They miss different things — which is the entire argument, and why the wording recommends rather than requires.

## Deviations

**P2's opening sentence changed.** It claimed the interview "covers one topic", which stops being true with these questions. Leaving it would repeat exactly the defect #54 fixed: a skill whose prose and procedure disagree. It now names two topics, and still lists everything it deliberately does not ask.

**Nothing enforces that review uses a different model.** No check reachable from CI can observe which model a session runs on, so this ships as recorded intent, not a wall — the distinction #43 was raised about.

## Retirement

#69 ships with this and is blocked by it: four named triggers for removing these questions once auto-selection makes them noise, and a requirement that "auto is good enough" be *measured* before it is claimed.
