### PR TITLE
Retire the review model that Rubber Duck already chooses

### DIFF
--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Independent verification agent. Reviews a PR against its Task issue — acceptance-criteria evidence, ownership boundaries, verification integrity, safety — and produces a pass/gap report. Reads and runs checks; does not modify implementation code.
+description: Independent Task-contract and governance auditor. Reviews a PR against its Task issue — linkage, acceptance evidence, CI integrity, ownership, deviations, and protected-control changes — and produces a pass/gap report. Not a general code-review agent; reads checks and does not modify implementation code.
 # Tool aliases per GitHub Docs "Custom agents configuration"
 # (docs.github.com/en/copilot/reference/custom-agents-configuration):
 # omitting `edit` removes the file-editing tools; `execute` stays because a
@@ -10,34 +10,49 @@ description: Independent verification agent. Reviews a PR against its Task issue
 tools: ["read", "search", "execute", "github/*"]
 ---
 
-You are the reviewer: the independent verification step between "an agent says
-it is done" and "a human merges it". Your independence is the point — do not
-take the implementing agent's report at face value, and do not fix the
+You are the Task-contract and governance auditor between "an agent says it is
+done" and "a human merges it". Your independence is the point — do not take
+the implementing agent's report at face value, and do not fix the
 implementation yourself (a reviewer who edits the code is no longer reviewing
 it; leave fixes to the implementer via review comments).
 
-Operate by `.github/instructions/code-review.instructions.md` (what to check,
-in order) and `.github/skills/verification/SKILL.md` (how to check it).
+Do not run a second general code-review pass. Official Rubber Duck owns
+in-loop design/implementation critique on supported surfaces; Copilot code
+review owns generic bug, vulnerability, and logic review. Surface a
+high-confidence defect you encounter, but your primary job is whether the PR
+honestly and safely satisfies its Task.
+
+Use `.github/instructions/code-review.instructions.md` for its Evidence
+through Deviation-honesty checks, in that order, and
+`.github/skills/verification/SKILL.md` for how to verify them. Its generic
+Craft pass belongs to Copilot code review unless craft blocks the Task or
+violates a written instruction.
 
 ## Procedure
 
 1. Load the Task issue behind the PR. If the PR has no `Closes #<n>` link,
-   that alone is a request-changes finding.
+   that alone is a `gaps` finding.
 2. Re-derive the claim: list the acceptance criteria and the evidence offered
-   for each. Where evidence is a command, rerun it if your environment allows;
-   where it is a CI check, confirm via `gh pr checks` rather than the PR
-   author's word.
+   for each. Verify the evidence table and CI verdict first. Re-run a command
+   only to resolve evidence that is absent, contradictory, or implausible
+   (`verification` §The layers); routine reproduction is duplicated cost.
 3. Diff-audit ownership: every changed path must fall inside the issue's
    File-ownership section.
 4. Hunt for silent deviations: behavior in the diff that the issue never asked
    for, or issue requirements with no corresponding change.
-5. Produce the report as a PR review:
-   - **Verdict:** approve / request changes.
+5. Audit governance safety: no credentials, unrequested external endpoints,
+   workflow/ruleset changes without an explicit mandate, or edits to protected
+   decision surfaces outside the declared ownership.
+6. Produce a portable report. Post it as a non-approving PR comment when
+   authenticated; otherwise return it to the requester marked **unrecorded**
+   so they post it before acting:
+   - **Recommended disposition:** pass / gaps.
    - **Evidence audit:** criterion → verified / unverified / failed, with how.
    - **Gaps:** ordered by severity, each with the smallest sufficient fix.
    - **Retro candidates:** anything you flagged that reviewers have flagged
      before — recommend a `retro:` instructions/skill change instead of
      repeating the comment forever.
 
-Stay proportionate: block on correctness, evidence, ownership, and safety;
-mention style only when it obscures meaning or violates a written instruction.
+Stay proportionate: report gaps in correctness, evidence, ownership, and safety;
+style and generic craft belong to Copilot code review unless they prevent the
+Task from succeeding or violate a written instruction.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,11 +72,9 @@ execution-plane surface: frontmatter, ceilings, English-only.
 Recorded during onboarding (P2); `auto` means the app decides.
 
 - **Implementation:** `auto`
-- **Review:** `auto`
 
-Dispatch implementation work on the first, layer-3 review on the second
-(`task-routing`, `verification`). When they differ, that is deliberate: a
-reviewer sharing the implementer's blind spot reviews less.
+Use it when dispatching implementation work. Review behavior is selected
+per Task and surface (`task-routing`, `verification`), not frozen here.
 
 ## Working a Task issue
 

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -90,7 +90,7 @@ routing first needs it (`exec:ide`), not interviewed up front.
 
 The interview covers what the repository cannot answer for itself: **how
 specification and design material reaches the scaffold**, and **which
-models run the work**. Everything else about the repository is
+model runs implementation work**. Everything else about the repository is
 discovered by P1/P3 or when work first needs it — path restrictions are
 declared per task in File ownership at decomposition time, secrets
 specifics surface when work first touches them (baseline guardrails
@@ -131,18 +131,14 @@ Ask in sequence, second step branching on the first answer:
 3. **Implementation model.** *"Which model should agents use for
    implementation work? Type a model name if you have a preference;
    `auto` is a safe answer and means the app decides."*
-4. **Review model.** *"And for reviewing that work? A different model
-   catches blind spots the implementing one shares. The same answer is
-   fine, and `auto` again means the app decides."*
 
-   These two are here because no later step can ask them: P1 reads
+   This answer is here because no later step can ask it: P1 reads
    manifests, P3 runs commands, and neither can learn a team's
-   preference. Take the answers as typed and **never suggest a model
-   name** — not in the question, not as an example, not as a default.
-   Naming one dates this skill to the month it was written, and the
-   adopter knows today's names better than it does. The reason in the
-   second question is a recommendation, not a rule; two identical
-   answers, or two `auto`s, are complete.
+   implementation preference. Take it as typed and **never suggest a
+   model name** — not in the question, not as an example, not as a
+   default. Naming one dates this skill to the month it was written, and
+   the adopter knows today's names better than it does. `auto` is a
+   complete answer.
 
 **Close P2 before starting P3** — verification is the long stretch, so
 give the adopter something to review during it:
@@ -221,9 +217,9 @@ unrun command.
   Repo-resident documents are **not** copied into `.github/docs/context/` — they
   stay in place and are read where they live. Do **not**
   write agreements — distillation is a separate, human-gated phase.
-- Record the P2 model answers verbatim in copilot-instructions' **Models**
-  block. Two unanswered questions are two `auto`s, which is a complete
-  answer and not a gap.
+- Record the P2 implementation-model answer verbatim in
+  copilot-instructions' **Models** block. An unanswered question is
+  `auto`, which is a complete answer and not a gap.
 - Do **not** touch `AGENTS.md` (Budget rule; behavior is project-independent).
 
 ### P5 — Prove

--- a/.github/skills/task-routing/SKILL.md
+++ b/.github/skills/task-routing/SKILL.md
@@ -116,10 +116,9 @@ change), but the effort tier is meaningful:
 | `fast` | Mechanical edits, renames, formatting, boilerplate | smaller/faster model |
 | `local` | Sensitive data, offline work | on-device model |
 
-Which model fills a tier is the adopter's answer, recorded in
-copilot-instructions' **Models** block — read it there rather than
-naming one here. Review is dispatched on the review model, which may
-differ from the implementation model on purpose.
+Which model fills an implementation tier is the adopter's answer,
+recorded in copilot-instructions' **Models** block — read it there rather
+than naming one here.
 
 ## Role suggestion
 
@@ -127,6 +126,19 @@ Suggest a role when a specialized definition exists in `.github/agents/`
 (e.g., `planner`, `orchestrator`, `reviewer`) or in the client's agent picker
 (e.g., security- or docs-focused agents). Leave as `default` otherwise; do not
 invent role names that no surface provides.
+
+## Review routing
+
+- On `exec:app` / `exec:cli`, use official Rubber Duck for in-loop critique
+  where the surface supports it (`verification`, layer 3). Never infer the
+  same support for `exec:cloud` or every IDE from CLI/app documentation.
+- Use the custom `reviewer` for every `risk:high` Task and every Task that
+  changes governance surfaces (agreements, `AGENTS.md`, agents/skills,
+  workflows/rulesets, CODEOWNERS, or CI guard scripts). It is optional for
+  ordinary Tasks with complete deterministic evidence.
+- When a routed surface lacks Rubber Duck and a cross-model critique matters,
+  name that independent review in the Task's Handoff notes. Choose it per
+  Task and surface; never freeze one reviewer model repository-wide.
 
 ## Re-routing
 

--- a/.github/skills/verification/SKILL.md
+++ b/.github/skills/verification/SKILL.md
@@ -28,12 +28,21 @@ is the cap and the exit, not an invitation to grind until green.
    tests, build. Runs locally and in CI. Binary outcomes only.
 2. **Security** — secret scanning, dependency review, code scanning. Never
    ship "temporary" suppressions without a linked issue.
-3. **AI review** — Copilot code review and/or the `reviewer` agent, guided by
-   `.github/instructions/code-review.instructions.md`. Catches claim/evidence
-   gaps and silent deviations before a human spends attention. Run it on the
-   review model recorded in copilot-instructions' **Models** block: a
-   reviewer sharing the implementer's blind spot reviews less, so where the
-   two differ, the difference is the point.
+3. **AI review** — three mechanisms, with different jobs:
+   - **In-loop critique:** official Rubber Duck, on surfaces where GitHub
+     supports it, gives the working agent a contrasting-model opinion on
+     plans, designs, implementations, and tests. It is not the final Task
+     audit, and unsupported surfaces are never assumed. GitHub currently
+     documents it for Copilot CLI and the Copilot app:
+     https://docs.github.com/en/copilot/concepts/agents/copilot-cli/rubber-duck
+   - **Generic code review:** Copilot code review looks for bugs, security
+     vulnerabilities, and logic defects in a diff or PR. Its findings are
+     advisory and do not satisfy human approval.
+   - **Task-contract audit:** the custom `reviewer` checks Task linkage,
+     acceptance evidence, CI/check integrity, File ownership, silent
+     deviations, and protected-governance changes. It is required for
+     `risk:high` and governance-surface Tasks, and optional otherwise
+     (`task-routing`, Review routing).
 4. **Human review** — judgment: is this the *right* change? Protected by
    branch ruleset (required PR + required checks + human approval on
    agent-authored PRs).

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,19 +45,25 @@ inherit what this one learned.
 
 ### Unreleased
 
-- Onboarding asks which model builds and which model doubts. Nothing had ever
-  asked, so every adopter ran on whatever their app defaulted to and no
-  session downstream could know otherwise — and unlike path restrictions or
-  the roadmap board, no later phase can discover it: P1 reads manifests, P3
-  runs commands, and neither learns a team's preference. P2 now asks two
-  free-text questions and P4 records the answers where `task-routing` and
-  `verification` read them. The second question carries its reason in one
-  clause — a reviewer sharing the implementer's blind spot reviews less — as
-  a recommendation, not a rule; two identical answers are complete, and so
-  are two `auto`s. **The scaffold names no model anywhere**: it holds the
-  adopter's answer and no opinion about which models exist this month. The
-  retirement condition ships with the feature (#69), because a question that
-  outlives its usefulness is how an interview gets slowly worse (#68).
+- The repository-wide review-model preference from #68 is retired after one
+  day: official Rubber Duck already selects a contrasting model for in-loop
+  critique and can improve centrally. Onboarding still records the
+  implementation model, but no longer asks for or stores a review model.
+  Review now has three explicit, non-overlapping jobs: Rubber Duck critiques
+  evolving work where supported; Copilot code review finds generic code
+  defects; the custom `reviewer` audits the Task contract, evidence,
+  ownership, deviations, and governance safety. Existing adopters may delete
+  the stale `- **Review:** ...` line and its explanatory paragraph from their
+  tuned copilot-instructions; leaving it is harmless because no skill reads it
+  anymore. This partially supersedes #68 and fulfills #69 (#74).
+- Onboarding asks which model builds. Nothing had ever asked, so every
+  adopter ran on whatever their app defaulted to and no session downstream
+  could know otherwise — and unlike path restrictions or the roadmap board,
+  no later phase can discover an implementation-model preference. P2 now asks
+  one free-text question and P4 records the answer where `task-routing` reads
+  it. `auto` is a complete answer. **The scaffold names no model anywhere**:
+  it holds the adopter's answer and no opinion about which models exist this
+  month (#68; its short-lived review-model half is superseded by #74).
 - Guard regression tests no longer spend six minutes sleeping through
   failures they deliberately created. Five ritual suites consumed 344 of the
   regression step's 361 seconds because every missing comment or broken link


### PR DESCRIPTION
Closes #74

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/74#issuecomment-5305400407

## What

The repository-wide review-model preference introduced by #68 is retired one day later. Official Rubber Duck already selects a contrasting model for in-loop critique on supported surfaces and can improve centrally; freezing another answer in onboarding would preserve a duplicate local policy.

The implementation-model question remains. Review is now split by responsibility, not by one repository-wide model.

## Responsibility split

| Mechanism | Owns | Does not own |
|---|---|---|
| Official Rubber Duck | In-loop critique of plans, designs, implementation and tests; contrasting-model opinion | Final Task audit; unsupported cloud/IDE surfaces |
| Official Copilot code review | Generic bugs, vulnerabilities and logic defects in local/PR diffs | Formal approval; complete Task-contract verification |
| Custom `reviewer` | Task linkage, acceptance evidence, CI/check integrity, File ownership, deviations and protected-governance changes | A second general code/craft pass; implementation fixes |
| Human/ruleset | Requirement interpretation, exceptions, formal approval and merge | Re-running the inner implementation loop |

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| P2 keeps implementation question only | Review question and two-answer guidance removed; implementation question and `auto` remain |
| Review field removed | `copilot-instructions.md` contains only `Implementation: auto`; no active `Review:` line or explanatory paragraph |
| P4 records one answer | P4 now says implementation-model answer singular |
| Routing is per Task/surface | New Review routing section names `exec:app`/`exec:cli` Rubber Duck support, refuses to infer `exec:cloud`/IDE support, and moves unsupported-surface review into Task Handoff notes |
| Review mechanisms separated | `verification` layer 3 is a three-part responsibility split with the official Rubber Duck URL |
| Custom reviewer narrowed | Description/procedure now Task-contract/governance-only; record-first verification; generic craft excluded; output is recommended `pass/gaps` |
| Objective reviewer trigger | Required for `risk:high` and governance-surface Tasks; optional for ordinary Tasks with deterministic evidence |
| Durable delivery | Non-approving PR comment when authenticated; otherwise returned as explicitly **unrecorded** for the requester to post before acting |
| Migration for adopters | Changelog says existing adopters may delete stale Review lines; leaving them is harmless because no skill reads them |
| No stale active references | grep over `.github` excluding raw docs finds no recorded-review-model/Review-field consumer |
| Verification | check-copilot-surface, check-md-links, check-changelog-refs, check-escalation-wording, git diff check and all 19 guard suites pass |

## Independent review

A contrasting-model Rubber Duck review was run before commit. It found three blocking contradictions, all fixed here:

1. `request-changes` remained in reviewer step 1 despite the new portable pass/gaps disposition.
2. The adjacent #68 changelog entry still described two questions as current.
3. The custom audit had no durable report channel after removing "PR review" wording.

It also required a surface spike. Recorded on #74: Rubber Duck is documented for CLI/app, not universally for cloud/IDE; Copilot code review is advisory; the custom reviewer remains necessary for Task-contract governance.

## Deviations / follow-ups

- `.github/instructions/code-review.instructions.md` still describes one shared six-step pass for every reviewer. It is outside this Task's ownership and is tracked by #76 rather than folded into this PR.
- Official Rubber Duck availability is not claimed outside documented/verified surfaces.
- #69 is superseded by this more precise partial retirement and will be closed after merge.
