### PR TITLE
Give each review mechanism one job

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -4,31 +4,64 @@ applyTo: "**"
 
 # Code Review Standards
 
-These standards guide Copilot code review, agent reviewers
-(`.github/agents/reviewer.agent.md`), and human reviewers alike. A PR in this
-repository is not just code — it is a claim that a Task issue's acceptance
-criteria are met. Review the claim, not only the diff.
+These standards guide in-loop Rubber Duck critique, Copilot code review,
+agent reviewers (`.github/agents/reviewer.agent.md`), and human reviewers. A
+PR in this repository is not just code — it is a claim that a Task issue's
+acceptance criteria are met. Review the claim, not only the diff.
 
-Check, in this order:
+They share one standard, not one job:
 
-1. **Evidence.** The PR references its Task issue (`Closes #<n>`) and the
+| Mechanism | Owns | Does not own |
+|---|---|---|
+| **Rubber Duck** (supported CLI/app surfaces) | In-loop critique of plans, designs, implementations, and tests; contrasting-model blind spots | Final Task audit, formal PR approval, or unsupported surfaces |
+| **Copilot code review** | Generic bugs, vulnerabilities, logic defects, and craft in a diff or PR | Task evidence/ownership completeness or formal approval; its result is advisory |
+| **Custom `reviewer`** | Task linkage, evidence, CI integrity, ownership, deviations, and governance safety | A second general code/craft pass or implementation fixes |
+| **Human + ruleset** | Requirement interpretation, exceptions, CODEOWNERS decisions, formal approval, and merge authority | Re-running the inner implementation loop |
+
+Official references: [Rubber Duck](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/rubber-duck)
+and [Copilot code review](https://docs.github.com/en/copilot/concepts/agents/code-review).
+Do not infer Rubber Duck support on surfaces GitHub has not documented or the
+adopter has not verified.
+
+Rubber Duck runs inside the work loop, before a PR audit, and is therefore not
+a numbered PR gate below. Review a PR in this order. A mechanism runs the
+checks assigned to it; a human may inspect any row. The custom reviewer is
+required only for `risk:high` and governance-surface Tasks (`task-routing`,
+Review routing); on ordinary Tasks the human owns checks 1–5 unless that
+reviewer is selected.
+
+1. **Evidence (custom reviewer + human).** The PR references its Task issue
+   (`Closes #<n>`) and the
    evidence table maps every acceptance criterion to a command, link, or
    artifact. `REQ-###` citations are expected only where such agreements
    exist. Criteria without evidence: request changes.
-2. **Ownership.** The diff stays inside the paths declared in the issue's
+2. **Ownership (custom reviewer + human).** The diff stays inside the paths
+   declared in the issue's
    "File ownership" section; a declared agreements wording rider
    (`docs.instructions.md`) is not a violation. Other out-of-scope files —
    even improvements — mean the plan and the work disagree: request changes
    and suggest `needs:replan`.
-3. **Verification integrity.** Tests were added or updated for new logic. No
-   test, lint rule, or CI check was deleted, skipped, or weakened to get green.
-4. **Safety.** No secrets or credentials; no new external endpoints that are
-   absent from the issue; no workflow/ruleset changes without explicit mandate.
-5. **Deviation honesty.** If the implementation deviates from the issue, the
+3. **Verification integrity (custom reviewer + human).** Tests were added or
+   updated for new logic. No test, lint rule, or CI check was deleted, skipped,
+   or weakened to get green.
+4. **Governance safety (custom reviewer + human).** No credentials,
+   unrequested external endpoints, workflow/ruleset changes without explicit
+   mandate, or edits to protected decision surfaces outside ownership.
+5. **Deviation honesty (custom reviewer + human).** If the implementation
+   deviates from the issue, the
    PR's "Deviations" section says so, and downstream issues were flagged.
    Silent deviations are the most expensive class of agent error — flag them
    even when the code itself is good.
-6. **Craft.** Only after 1–5 pass, review naming, structure, duplication, and
-   comment quality. Prefer a few high-value comments over many nits; recurring
-   nits belong in an instructions file via the retro skill, not in review
-   threads forever.
+6. **Code defects (Copilot code review + human).** Hunt for substantive bugs,
+   vulnerabilities, logic errors, and performance failures beyond check 3's
+   test-integrity obligation. Rubber Duck should already have challenged
+   these in-loop on supported surfaces. AI findings are advisory; they never
+   satisfy required approval.
+7. **Craft (Copilot code review + human).** Treat naming, structure,
+   duplication, and comment quality as lower priority than substantive
+   findings. Prefer a few high-value comments over many nits; recurring nits
+   belong in an instructions file via the retro skill, not in review threads
+   forever.
+
+When no AI review mechanism is enabled or available on the routed surface,
+the human reviewer owns checks 6–7 as well.

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,15 @@ inherit what this one learned.
 
 ### Unreleased
 
+- Shared code-review instructions now assign each check to a mechanism instead
+  of asking every reviewer to perform one impossible all-purpose pass. Rubber
+  Duck owns supported-surface in-loop critique; Copilot code review owns
+  generic defects and craft; the custom `reviewer` owns Task linkage,
+  acceptance evidence, CI integrity, File ownership, deviations, and
+  governance safety; humans/rulesets retain requirement interpretation,
+  exceptions, formal approval, and merge authority. The first five ordered
+  checks still map exactly to the custom reviewer's contract, while official
+  AI review remains advisory and never satisfies approval (#76).
 - The repository-wide review-model preference from #68 is retired after one
   day: official Rubber Duck already selects a contrasting model for in-loop
   critique and can improve centrally. Onboarding still records the


### PR DESCRIPTION
Closes #76

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/76#issuecomment-5305459046

## What

The shared review instructions said Copilot code review, agent reviewers and humans all ran one six-step pass. After #74 that was contradictory — and official code review could never satisfy the old Craft precondition because it does not own Task evidence or File ownership.

## Responsibility table

| Mechanism | Assigned work |
|---|---|
| Rubber Duck | In-loop critique before PR audit, supported surfaces only |
| Copilot code review | Generic bugs, vulnerabilities, logic defects and craft; advisory only |
| Custom reviewer | Ordered checks 1–5: evidence, ownership, verification integrity, governance safety, deviation honesty |
| Human + ruleset | Requirement interpretation, exceptions, CODEOWNERS, approval and merge authority; fallback for checks whose AI mechanism is unavailable |

## Evidence

| Acceptance criterion | Evidence |
|---|---|
| Each check names its owner | Mechanism table plus owner tags on all seven numbered checks |
| Custom reviewer mapping exact | Shared checks 1–5 are Evidence through Deviation honesty, exactly as `reviewer.agent.md` references them |
| Official mechanisms stay advisory | Table and check 6 state they never satisfy required approval |
| Rubber Duck time order correct | Explicitly outside the numbered PR gate: it runs in-loop before PR audit |
| Human authority preserved | Human/ruleset row owns requirements, exceptions, CODEOWNERS, formal approval and merge |
| No-AI fallback | Ordinary Tasks leave checks 1–5 to human when custom reviewer is absent; checks 6–7 fall to human when AI review is unavailable |
| Surface caveat | Rubber Duck support is not inferred beyond GitHub-documented/verified surfaces |
| Verification | check-copilot-surface, check-md-links, check-changelog-refs and git diff check pass |

## Independent review

A contrasting-model Rubber Duck review found no blocking issues. Its non-blocking findings led to three fixes before commit:

1. Removed Rubber Duck from the numbered late-PR sequence and kept it in-loop.
2. Removed duplicate "missing test cases" ownership from generic code review; check 3 remains the gating test-integrity obligation.
3. Added explicit human fallback when optional AI mechanisms are unavailable.

## Deviations

None.
