### PR TITLE
Report effective default-branch governance status

### DIFF
--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -37,8 +37,7 @@ done
 case "$REPO" in */*) ;; *) usage ;; esac
 CHECKS="$(printf '%s' "$CHECKS" | tr -d ' ' | tr -s ',' | sed 's/^,//;s/,$//')"
 [ -n "$CHECKS" ] || usage
-command -v gh >/dev/null 2>&1 || { echo "error: gh CLI not found" >&2; exit 2; }
-command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 2; }
+for t in gh jq; do command -v "$t" >/dev/null 2>&1 || { echo "error: $t not found" >&2; exit 2; }; done
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/governance-status.XXXXXX")" || exit 2
 trap 'rm -rf "$WORK"' EXIT
 TAB="$(printf '\t')"
@@ -81,8 +80,7 @@ emit() {
 fetch repo "repos/$REPO"
 DEFB="" OWNER=""
 if [ "$(st repo)" = ok ]; then
-  DEFB="$(jqr '.default_branch // empty' repo)"
-  OWNER="$(jqr '.owner.type // empty' repo)"
+  DEFB="$(jqr '.default_branch // empty' repo)"; OWNER="$(jqr '.owner.type // empty' repo)"
 fi
 if [ -n "$DEFB" ]; then
   fetch rules "repos/$REPO/rules/branches/$DEFB"
@@ -90,8 +88,7 @@ if [ -n "$DEFB" ]; then
   fetch runs "repos/$REPO/commits/$DEFB/check-runs?filter=latest&per_page=100" page
   fetch clog "repos/$REPO/contents/SCAFFOLD-CHANGELOG.md?ref=$DEFB" raw
 else
-  for name in rules wf runs clog; do echo fail > "$WORK/$name.rc"; done
-fi
+  for name in rules wf runs clog; do echo fail > "$WORK/$name.rc"; done; fi
 RULES=0
 [ "$(st rules)" != ok ] || RULES=1
 
@@ -264,43 +261,50 @@ fi
 
 if [ "$(st repo)" != ok ]; then emit merge_queue.applicability UNKNOWN "repository metadata unavailable" "$BASE"
 elif [ "$OWNER" = User ]; then emit merge_queue.applicability N/A "owner_type=User; merge queue not applicable" 0
-elif [ "$RULES" = 1 ] && [ "$MQN" -gt 0 ]; then
-  # A merge_queue rule is ACTIVE only with observed merge_group workflow
-  # coverage; incomplete evidence stays UNKNOWN/UNCHECKABLE and gates.
-  MQCOV=0
-  fetch wfd "repos/$REPO/contents/.github/workflows?ref=$DEFB"
-  if [ "$(st wfd)" = fail ]; then MQCOV=unknown
-  elif [ "$(st wfd)" = ok ]; then
-    while IFS= read -r wfn; do
-      [ -n "$wfn" ] || continue
-      fetch wff "repos/$REPO/contents/.github/workflows/$wfn?ref=$DEFB" raw
-      if [ "$(st wff)" != ok ]; then MQCOV=unknown; break; fi
-      ! sed 's/#.*//' "$WORK/wff.json" | grep -qw merge_group || MQCOV=$((MQCOV + 1))
-    done <<EOF
+else
+  # Public repositories are eligible by repository evidence alone; private
+  # ones need plan proof via GET /orgs/{owner}, failing closed, and a free
+  # plan is ineligible before any rule or coverage evidence is consulted.
+  PRIV="$(jqr '.private' repo)" OPLAN=eligible
+  if [ "$PRIV" = true ]; then
+    fetch orgp "orgs/${REPO%%/*}"
+    OPLAN=""; [ "$(st orgp)" != ok ] || OPLAN="$(jqr '.plan.name // empty' orgp)"
+  fi
+  if [ -z "$OPLAN" ]; then emit merge_queue.applicability UNKNOWN "organization plan evidence unavailable" "$BASE"
+  elif [ "$PRIV" = true ] && [ "$OPLAN" = free ]; then emit merge_queue.applicability N/A "private repository on free plan is ineligible" 0
+  elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" "$BASE"
+  elif [ "$MQN" -gt 0 ]; then
+    MQCOV=0
+    fetch wfd "repos/$REPO/contents/.github/workflows?ref=$DEFB"
+    if [ "$(st wfd)" = fail ]; then MQCOV=unknown
+    elif [ "$(st wfd)" = ok ]; then
+      while IFS= read -r wfn; do
+        [ -n "$wfn" ] || continue
+        fetch wff "repos/$REPO/contents/.github/workflows/$wfn?ref=$DEFB" raw
+        if [ "$(st wff)" != ok ]; then MQCOV=unknown; break; fi
+        # Coverage means a genuine merge_group trigger under a top-level on:
+        # block; comments, quotes, script strings, and scalars never count.
+        if sed 's/#.*//; s/["'\'']//g' "$WORK/wff.json" | awk '
+          /^[^[:blank:]]/ { b = /^on[[:blank:]]*:/; if (b && /[[,[:blank:]]merge_group([],[:blank:]]|$)/) f=1; next }
+          b && /^[[:blank:]]+(-[[:blank:]]*)?merge_group[[:blank:]]*(:|$)/ { f=1 }
+          END { exit !f }'; then MQCOV=$((MQCOV + 1)); fi
+      done <<EOF
 $(jqr '.[]? | select(.type == "file") | .name' wfd)
 EOF
-  fi
-  if [ "$MQCOV" = unknown ]; then
-    emit merge_queue.applicability UNKNOWN "merge_group workflow coverage evidence unavailable" "$BASE"
-  elif [ "$MQCOV" -gt 0 ]; then
-    emit merge_queue.applicability ACTIVE "merge_queue rule active$MQQ; merge_group coverage in $MQCOV workflow(s)" 0
-  else
-    emit merge_queue.applicability UNCHECKABLE "merge_queue rule active without observed merge_group workflow coverage" "$BASE"
-  fi
-elif [ "$(jqr '.private' repo)" = true ] && [ "$(jqr '.plan.name // empty' repo)" = free ]; then
-  emit merge_queue.applicability N/A "private repository on free plan is ineligible" 0
-elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" "$BASE"
-else emit merge_queue.applicability UNCHECKABLE "organization repository without plan, eligibility, rule, or merge_group evidence" "$BASE"; fi
+    fi
+    if [ "$MQCOV" = unknown ]; then emit merge_queue.applicability UNKNOWN "merge_group workflow coverage evidence unavailable" "$BASE"
+    elif [ "$MQCOV" -gt 0 ]; then emit merge_queue.applicability ACTIVE "merge_queue rule active$MQQ; merge_group coverage in $MQCOV workflow(s)" 0
+    else emit merge_queue.applicability UNCHECKABLE "merge_queue rule active without observed merge_group workflow coverage" "$BASE"; fi
+  else emit merge_queue.applicability UNCHECKABLE "eligible repository without a merge_queue rule" "$BASE"; fi
+fi
 
 while IFS="$TAB" read -r rid rtyp rsrc; do
   [ -n "$rid" ] || continue
   if [ "$(st "rs$rid")" = ok ]; then
     n="$(wc -l < "$WORK/actors.$rid" | tr -d ' ')"
     emit "bypass.ruleset.$rid" ACTIVE "source=$rtyp:$rsrc actors=$n" "$BASE"
-    i=0
-    while IFS= read -r actor; do
-      i=$((i + 1))
-      emit "bypass.ruleset.$rid.actor.$i" ACTIVE "$actor" 0
+    i=0; while IFS= read -r actor; do
+      i=$((i + 1)); emit "bypass.ruleset.$rid.actor.$i" ACTIVE "$actor" 0
     done < "$WORK/actors.$rid"
   else
     emit "bypass.ruleset.$rid" UNKNOWN "ruleset detail unavailable ($rtyp:$rsrc)" "$BASE"

--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -262,13 +262,35 @@ else
   esac
 fi
 
-if [ "$(st repo)" != ok ]; then emit merge_queue.applicability UNKNOWN "repository metadata unavailable" 0
+if [ "$(st repo)" != ok ]; then emit merge_queue.applicability UNKNOWN "repository metadata unavailable" "$BASE"
 elif [ "$OWNER" = User ]; then emit merge_queue.applicability N/A "owner_type=User; merge queue not applicable" 0
-elif [ "$RULES" = 1 ] && [ "$MQN" -gt 0 ]; then emit merge_queue.applicability ACTIVE "merge_queue rule active$MQQ" 0
+elif [ "$RULES" = 1 ] && [ "$MQN" -gt 0 ]; then
+  # A merge_queue rule is ACTIVE only with observed merge_group workflow
+  # coverage; incomplete evidence stays UNKNOWN/UNCHECKABLE and gates.
+  MQCOV=0
+  fetch wfd "repos/$REPO/contents/.github/workflows?ref=$DEFB"
+  if [ "$(st wfd)" = fail ]; then MQCOV=unknown
+  elif [ "$(st wfd)" = ok ]; then
+    while IFS= read -r wfn; do
+      [ -n "$wfn" ] || continue
+      fetch wff "repos/$REPO/contents/.github/workflows/$wfn?ref=$DEFB" raw
+      if [ "$(st wff)" != ok ]; then MQCOV=unknown; break; fi
+      ! sed 's/#.*//' "$WORK/wff.json" | grep -qw merge_group || MQCOV=$((MQCOV + 1))
+    done <<EOF
+$(jqr '.[]? | select(.type == "file") | .name' wfd)
+EOF
+  fi
+  if [ "$MQCOV" = unknown ]; then
+    emit merge_queue.applicability UNKNOWN "merge_group workflow coverage evidence unavailable" "$BASE"
+  elif [ "$MQCOV" -gt 0 ]; then
+    emit merge_queue.applicability ACTIVE "merge_queue rule active$MQQ; merge_group coverage in $MQCOV workflow(s)" 0
+  else
+    emit merge_queue.applicability UNCHECKABLE "merge_queue rule active without observed merge_group workflow coverage" "$BASE"
+  fi
 elif [ "$(jqr '.private' repo)" = true ] && [ "$(jqr '.plan.name // empty' repo)" = free ]; then
   emit merge_queue.applicability N/A "private repository on free plan is ineligible" 0
-elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" 0
-else emit merge_queue.applicability UNCHECKABLE "organization repository without plan, rule, or merge_group evidence" 0; fi
+elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" "$BASE"
+else emit merge_queue.applicability UNCHECKABLE "organization repository without plan, eligibility, rule, or merge_group evidence" "$BASE"; fi
 
 while IFS="$TAB" read -r rid rtyp rsrc; do
   [ -n "$rid" ] || continue

--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -263,15 +263,14 @@ if [ "$(st repo)" != ok ]; then emit merge_queue.applicability UNKNOWN "reposito
 elif [ "$OWNER" = User ]; then emit merge_queue.applicability N/A "owner_type=User; merge queue not applicable" 0
 else
   # Public repositories are eligible by repository evidence alone; private
-  # ones need plan proof via GET /orgs/{owner}, failing closed, and a free
-  # plan is ineligible before any rule or coverage evidence is consulted.
+  # ones require a recognized plan from GET /orgs/{owner}, failing closed.
   PRIV="$(jqr '.private' repo)" OPLAN=eligible
   if [ "$PRIV" = true ]; then
     fetch orgp "orgs/${REPO%%/*}"
     OPLAN=""; [ "$(st orgp)" != ok ] || OPLAN="$(jqr '.plan.name // empty' orgp)"
   fi
-  if [ -z "$OPLAN" ]; then emit merge_queue.applicability UNKNOWN "organization plan evidence unavailable" "$BASE"
-  elif [ "$PRIV" = true ] && [ "$OPLAN" = free ]; then emit merge_queue.applicability N/A "private repository on free plan is ineligible" 0
+  if [ -z "$OPLAN" ] || { [ "$PRIV" = true ] && [ "$OPLAN" != free ] && [ "$OPLAN" != team ] && [ "$OPLAN" != enterprise ]; }; then emit merge_queue.applicability UNKNOWN "organization plan evidence unavailable" "$BASE"
+  elif [ "$PRIV" = true ] && { [ "$OPLAN" = free ] || [ "$OPLAN" = team ]; }; then emit merge_queue.applicability N/A "private repository plan=$OPLAN is ineligible" 0
   elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" "$BASE"
   elif [ "$MQN" -gt 0 ]; then
     MQCOV=0

--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# governance-status.sh — read-only default-branch governance sensor
+# (ADR-0004 decisions 1, 2, 4, 5). Compares effective branch rules, Actions
+# posture, CODEOWNERS tuning, and merge-queue applicability against an
+# explicitly declared solo or team intent (solo = the setup-ruleset.sh
+# minimum; stronger observed settings never make solo unhealthy). Aggregates
+# every active rule source including parent rulesets, qualifies
+# ruleset-derived controls with their bypass actors, and reports missing
+# evidence as UNKNOWN or UNCHECKABLE — never as safe. GET-only; nothing is
+# mutated and no profile is persisted.
+#
+# Output: deterministic `key<TAB>state<TAB>detail` lines.
+# Exit: 0 healthy with complete evidence; 1 required control OFF;
+#       2 usage or dependency error; 3 required evidence missing (beats 1).
+
+set -u
+
+usage() {
+  echo "Usage: governance-status.sh -R owner/repo [--profile solo|team]" >&2
+  echo "                            [--checks ctx1,ctx2,...]" >&2
+  exit 2
+}
+
+REPO="" PROFILE=""
+CHECKS="quality,task-ritual,scaffold-self-check,copilot-surface"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -R|--repo) [ -n "${2:-}" ] || usage; REPO="$2"; shift 2 ;;
+    --profile)
+      case "${2:-}" in solo|team) PROFILE="$2" ;; *) usage ;; esac
+      shift 2 ;;
+    --checks) [ -n "${2:-}" ] || usage; CHECKS="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[ -n "$REPO" ] || usage
+case "$REPO" in */*) ;; *) usage ;; esac
+CHECKS="$(printf '%s' "$CHECKS" | tr -d ' ' | tr -s ',' | sed 's/^,//;s/,$//')"
+[ -n "$CHECKS" ] || usage
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 2; }
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/governance-status.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK"' EXIT
+TAB="$(printf '\t')"
+
+BASE=0 TEAM=0 UNMET=0 MISSING=0
+[ -z "$PROFILE" ] || BASE=1
+[ "$PROFILE" != team ] || TEAM=1
+
+# fetch <name> <path> [raw] — read-only GET; records ok|404|fail in
+# $WORK/<name>.rc. The only gh invocation shape this sensor ever uses.
+fetch() {
+  local name="$1" path="$2" rc=0
+  if [ "${3:-}" = raw ]; then
+    gh api -H "Accept: application/vnd.github.raw" "$path" \
+      > "$WORK/$name.json" 2> "$WORK/$name.err" || rc=$?
+  else
+    gh api "$path" > "$WORK/$name.json" 2> "$WORK/$name.err" || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then echo ok
+  elif grep -q "HTTP 404" "$WORK/$name.err"; then echo 404
+  else echo fail
+  fi > "$WORK/$name.rc"
+}
+st() { cat "$WORK/$1.rc" 2>/dev/null || echo fail; }
+jqr() { jq -r "$1" "$WORK/$2.json"; }
+
+# emit <key> <state> <detail> <required-flag> — required OFF counts toward
+# exit 1; required UNKNOWN/UNCHECKABLE counts toward exit 3 (which outranks).
+emit() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3"
+  [ "${4:-0}" = 1 ] || return 0
+  case "$2" in
+    OFF) UNMET=$((UNMET + 1)) ;;
+    UNKNOWN|UNCHECKABLE) MISSING=$((MISSING + 1)) ;;
+  esac
+}
+
+fetch repo "repos/$REPO"
+DEFB="" OWNER=""
+if [ "$(st repo)" = ok ]; then
+  DEFB="$(jqr '.default_branch // empty' repo)"
+  OWNER="$(jqr '.owner.type // empty' repo)"
+fi
+if [ -n "$DEFB" ]; then
+  fetch rules "repos/$REPO/rules/branches/$DEFB"
+  fetch wf "repos/$REPO/actions/permissions/workflow"
+  fetch runs "repos/$REPO/commits/$DEFB/check-runs?per_page=100"
+  fetch clog "repos/$REPO/contents/SCAFFOLD-CHANGELOG.md?ref=$DEFB" raw
+else
+  for name in rules wf runs clog; do echo fail > "$WORK/$name.rc"; done
+fi
+RULES=0
+[ "$(st rules)" != ok ] || RULES=1
+
+# Aggregate every effective rule of a type across all active sources: the
+# strongest approval threshold, any-source booleans, and the union of
+# contributing ruleset ids. One named ruleset is never the answer.
+PRN=0 APPR=0 DSM=false LPA=false COR=false RTR=false STRICT=false MQN=0
+PRSRC="" RSCSRC="" MQSRC=""
+if [ "$RULES" = 1 ]; then
+  # shellcheck disable=SC2016  # single-quoted jq program, as in setup-ruleset.sh
+  IFS="$TAB" read -r PRN APPR DSM LPA COR RTR STRICT MQN PRSRC RSCSRC MQSRC <<EOF
+$(jqr '[.[]|select(.type=="pull_request")] as $p
+  | [.[]|select(.type=="required_status_checks")] as $c
+  | [.[]|select(.type=="merge_queue")] as $m
+  | def srcs(x): ([x[].ruleset_id]|unique|map(tostring)|join(","))
+      | if . == "" then "-" else . end;
+  [($p|length),
+   ([$p[].parameters.required_approving_review_count]|max // 0),
+   ([$p[].parameters.dismiss_stale_reviews_on_push]|any),
+   ([$p[].parameters.require_last_push_approval]|any),
+   ([$p[].parameters.require_code_owner_review]|any),
+   ([$p[].parameters.required_review_thread_resolution]|any),
+   ([$c[].parameters.strict_required_status_checks_policy]|any),
+   ($m|length), srcs($p), srcs($c), srcs($m)] | @tsv' rules)
+EOF
+  [ -n "$PRN" ] || RULES=0
+  for v in PRSRC RSCSRC MQSRC; do
+    eval "[ \"\$$v\" != - ] || $v=\"\""
+  done
+fi
+
+# Fetch every contributing ruleset detail: bypass actors qualify the claim,
+# and a failed detail read is UNKNOWN, never an empty bypass list.
+if [ "$RULES" = 1 ]; then
+  jqr '[.[]|{id:.ruleset_id,t:.ruleset_source_type,s:.ruleset_source}]
+    | unique_by(.id)[] | "\(.id)\t\(.t)\t\(.s)"' rules > "$WORK/srcs"
+else
+  : > "$WORK/srcs"
+fi
+while IFS="$TAB" read -r rid rtyp rsrc; do
+  [ -n "$rid" ] || continue
+  case "$rtyp" in
+    Repository) fetch "rs$rid" "repos/$rsrc/rulesets/$rid" ;;
+    Organization) fetch "rs$rid" "orgs/$rsrc/rulesets/$rid" ;;
+    *) echo fail > "$WORK/rs$rid.rc" ;;
+  esac
+  [ "$(st "rs$rid")" = ok ] || continue
+  jqr '.bypass_actors // [] | sort_by(.actor_type, .actor_id)[]
+    | "actor_type=\(.actor_type) actor_id=\(.actor_id // "none") bypass_mode=\(.bypass_mode)"' \
+    "rs$rid" > "$WORK/actors.$rid"
+  jqr '.bypass_actors // [] | sort_by(.actor_type, .actor_id)
+    | map("\(.actor_type):\(.actor_id // "none"):\(.bypass_mode)") | join(",")' \
+    "rs$rid" > "$WORK/qual.$rid"
+done < "$WORK/srcs"
+
+# qual_for <csv-ruleset-ids> — visible bypass qualifier for a ruleset-derived
+# control; unknown evidence is surfaced, never dropped.
+qual_for() {
+  local ids="$1" id q acc=""
+  QUAL=""
+  [ -n "$ids" ] || return 0
+  printf '%s\n' "$ids" | tr ',' '\n' > "$WORK/qids"
+  while IFS= read -r id; do
+    if [ "$(st "rs$id")" != ok ]; then QUAL=" bypass=unknown"; return 0; fi
+    q="$(cat "$WORK/qual.$id")"
+    [ -z "$q" ] || acc="$acc,$q"
+  done < "$WORK/qids"
+  [ -z "$acc" ] || QUAL=" bypass=${acc#,}"
+}
+qual_for "$PRSRC"; PQ="$QUAL"
+qual_for "$RSCSRC"; CQ="$QUAL"
+qual_for "$MQSRC"; MQQ="$QUAL"
+
+if [ -n "$DEFB" ]; then emit repository.default_branch ACTIVE "$DEFB" "$BASE"
+else emit repository.default_branch UNKNOWN "repository metadata unavailable" "$BASE"; fi
+if [ -n "$PROFILE" ]; then emit governance.profile ACTIVE "$PROFILE" 1
+else emit governance.profile UNKNOWN "no profile declared; pass --profile solo|team" 1; fi
+if [ "$RULES" != 1 ]; then
+  emit pull_request.required_approving_review_count UNKNOWN "effective rules unavailable" "$BASE"
+elif [ "$PRN" = 0 ] || [ "$APPR" -lt 1 ]; then
+  emit pull_request.required_approving_review_count OFF "count=$APPR (no approving-review requirement)" "$BASE"
+else
+  emit pull_request.required_approving_review_count ACTIVE "count=$APPR$PQ" "$BASE"
+fi
+
+# rule_row <key> <rule-count> <bool> <qual> <absent-detail> <required>
+rule_row() {
+  if [ "$RULES" != 1 ]; then emit "$1" UNKNOWN "effective rules unavailable" "$6"
+  elif [ "$2" = 0 ]; then emit "$1" OFF "$5" "$6"
+  elif [ "$3" = true ]; then emit "$1" ACTIVE "true$4" "$6"
+  else emit "$1" OFF "false$4" "$6"
+  fi
+}
+rule_row pull_request.dismiss_stale_reviews "$PRN" "$DSM" "$PQ" "no pull_request rule in effect" "$TEAM"
+rule_row pull_request.require_last_push_approval "$PRN" "$LPA" "$PQ" "no pull_request rule in effect" "$TEAM"
+rule_row pull_request.require_code_owner_review "$PRN" "$COR" "$PQ" "no pull_request rule in effect" "$TEAM"
+rule_row pull_request.required_review_thread_resolution "$PRN" "$RTR" "$PQ" "no pull_request rule in effect" "$TEAM"
+RSCN=0
+[ -z "$RSCSRC" ] || RSCN=1
+rule_row required_checks.strict_policy "$RSCN" "$STRICT" "$CQ" "no required_status_checks rule in effect" "$TEAM"
+
+# Requested contexts: presence is required for both profiles; source binding
+# (configured integration vs the observed issuing GitHub App ID — an App ID,
+# not an installation ID) is informational N/A for solo, required for team.
+printf '%s\n' "$CHECKS" | tr ',' '\n' > "$WORK/ctxs"
+while IFS= read -r ctx; do
+  [ -n "$ctx" ] || continue
+  pres=unknown cfg=unknown obs=unknown
+  if [ "$RULES" = 1 ]; then
+    IFS="$TAB" read -r pres cfg <<EOF
+$(jq -r --arg c "$ctx" '[.[]|select(.type=="required_status_checks")
+  .parameters.required_status_checks[]|select(.context==$c)] as $e
+  | [($e|length), ([$e[].integration_id // empty]|unique|map(tostring)
+  | join(",") | if . == "" then "none" else . end)] | @tsv' "$WORK/rules.json")
+EOF
+  fi
+  if [ "$(st runs)" = ok ]; then
+    obs="$(jq -r --arg c "$ctx" '[.check_runs[]|select(.name==$c)|.app.id // "none"]
+      | unique|map(tostring)|join(",") | if . == "" then "none" else . end' "$WORK/runs.json")"
+  fi
+  if [ "$pres" = unknown ]; then emit "required_checks.context.$ctx" UNKNOWN "effective rules unavailable" "$BASE"
+  elif [ "$pres" -gt 0 ]; then emit "required_checks.context.$ctx" ACTIVE "required by effective rules$CQ" "$BASE"
+  else emit "required_checks.context.$ctx" OFF "not required by effective rules" "$BASE"; fi
+  det="configured=$cfg observed=$obs"
+  if [ "$TEAM" != 1 ]; then emit "required_check_source.$ctx" N/A "$det (informational for solo intent)" 0
+  elif [ "$cfg" = unknown ]; then emit "required_check_source.$ctx" UNKNOWN "$det; effective rules unavailable" 1
+  elif [ "$obs" = unknown ]; then emit "required_check_source.$ctx" UNKNOWN "$det; check-run evidence unavailable" 1
+  elif [ "$obs" = none ]; then emit "required_check_source.$ctx" UNCHECKABLE "$det; no check run observed" 1
+  elif [ "${obs#*,}" != "$obs" ]; then emit "required_check_source.$ctx" UNCHECKABLE "multiple issuing app ids: $obs" 1
+  elif [ "$cfg" != "$obs" ]; then emit "required_check_source.$ctx" OFF "$det" 1
+  else emit "required_check_source.$ctx" ACTIVE "$det" 1; fi
+done < "$WORK/ctxs"
+
+if [ "$(st wf)" = ok ]; then
+  PERM="$(jqr '.default_workflow_permissions // "unknown"' wf)"
+  APPROVE="$(jqr '.can_approve_pull_request_reviews' wf)"
+  if [ "$PERM" = read ]; then emit actions.default_workflow_permissions ACTIVE read "$BASE"
+  else emit actions.default_workflow_permissions OFF "$PERM (expected read)" "$BASE"; fi
+  if [ "$APPROVE" = false ]; then emit actions.can_approve_pull_request_reviews ACTIVE false "$BASE"
+  else emit actions.can_approve_pull_request_reviews OFF "$APPROVE (expected false)" "$BASE"; fi
+else
+  emit actions.default_workflow_permissions UNKNOWN "actions permissions unavailable" "$BASE"
+  emit actions.can_approve_pull_request_reviews UNKNOWN "actions permissions unavailable" "$BASE"
+fi
+
+# CODEOWNERS tuning, read from the default branch. A template tree
+# (scaffold marker sha=unknown) legitimately carries CUSTOMIZE guidance.
+MARKER=""
+if [ "$(st clog)" = ok ]; then
+  MARKER="$(sed -n 's/.*scaffold-version:.* sha=\([^ ]*\).*/\1/p' "$WORK/clog.json" | head -n 1)"
+fi
+if [ "$(st clog)" != ok ] || [ -z "$MARKER" ]; then
+  emit codeowners.tuning UNKNOWN "scaffold marker unavailable on default branch" "$TEAM"
+elif [ "$MARKER" = unknown ]; then
+  emit codeowners.tuning N/A "template tree (sha=unknown); CUSTOMIZE guidance is expected" "$TEAM"
+else
+  fetch co "repos/$REPO/contents/.github/CODEOWNERS?ref=$DEFB" raw
+  case "$(st co)" in
+    ok)
+      if grep -q CUSTOMIZE "$WORK/co.json"; then
+        emit codeowners.tuning OFF "adopted tree with unresolved CUSTOMIZE ownership" "$TEAM"
+      else
+        emit codeowners.tuning ACTIVE "tuned CODEOWNERS on default branch (sha=$MARKER)" "$TEAM"
+      fi ;;
+    404) emit codeowners.tuning OFF "adopted tree without .github/CODEOWNERS" "$TEAM" ;;
+    *) emit codeowners.tuning UNKNOWN "CODEOWNERS evidence unreadable" "$TEAM" ;;
+  esac
+fi
+
+if [ "$(st repo)" != ok ]; then emit merge_queue.applicability UNKNOWN "repository metadata unavailable" 0
+elif [ "$OWNER" = User ]; then emit merge_queue.applicability N/A "owner_type=User; merge queue not applicable" 0
+elif [ "$RULES" = 1 ] && [ "$MQN" -gt 0 ]; then emit merge_queue.applicability ACTIVE "merge_queue rule active$MQQ" 0
+elif [ "$(jqr '.private' repo)" = true ] && [ "$(jqr '.plan.name // empty' repo)" = free ]; then
+  emit merge_queue.applicability N/A "private repository on free plan is ineligible" 0
+elif [ "$RULES" != 1 ]; then emit merge_queue.applicability UNKNOWN "effective rules unavailable" 0
+else emit merge_queue.applicability UNCHECKABLE "organization repository without plan, rule, or merge_group evidence" 0; fi
+
+while IFS="$TAB" read -r rid rtyp rsrc; do
+  [ -n "$rid" ] || continue
+  if [ "$(st "rs$rid")" = ok ]; then
+    n="$(wc -l < "$WORK/actors.$rid" | tr -d ' ')"
+    emit "bypass.ruleset.$rid" ACTIVE "source=$rtyp:$rsrc actors=$n" "$BASE"
+    i=0
+    while IFS= read -r actor; do
+      i=$((i + 1))
+      emit "bypass.ruleset.$rid.actor.$i" ACTIVE "$actor" 0
+    done < "$WORK/actors.$rid"
+  else
+    emit "bypass.ruleset.$rid" UNKNOWN "ruleset detail unavailable ($rtyp:$rsrc)" "$BASE"
+  fi
+done < "$WORK/srcs"
+
+[ "$MISSING" -eq 0 ] || exit 3
+[ "$UNMET" -eq 0 ] || exit 1
+exit 0

--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -47,13 +47,15 @@ BASE=0 TEAM=0 UNMET=0 MISSING=0
 [ -z "$PROFILE" ] || BASE=1
 [ "$PROFILE" != team ] || TEAM=1
 
-# fetch <name> <path> [raw] — read-only GET; records ok|404|fail in
-# $WORK/<name>.rc. The only gh invocation shape this sensor ever uses.
+# fetch <name> <path> [raw|page] — read-only GET; records ok|404|fail in
+# $WORK/<name>.rc. The only gh invocation shapes this sensor ever uses.
 fetch() {
   local name="$1" path="$2" rc=0
   if [ "${3:-}" = raw ]; then
     gh api -H "Accept: application/vnd.github.raw" "$path" \
       > "$WORK/$name.json" 2> "$WORK/$name.err" || rc=$?
+  elif [ "${3:-}" = page ]; then
+    gh api --paginate "$path" > "$WORK/$name.json" 2> "$WORK/$name.err" || rc=$?
   else
     gh api "$path" > "$WORK/$name.json" 2> "$WORK/$name.err" || rc=$?
   fi
@@ -85,7 +87,7 @@ fi
 if [ -n "$DEFB" ]; then
   fetch rules "repos/$REPO/rules/branches/$DEFB"
   fetch wf "repos/$REPO/actions/permissions/workflow"
-  fetch runs "repos/$REPO/commits/$DEFB/check-runs?per_page=100"
+  fetch runs "repos/$REPO/commits/$DEFB/check-runs?filter=latest&per_page=100" page
   fetch clog "repos/$REPO/contents/SCAFFOLD-CHANGELOG.md?ref=$DEFB" raw
 else
   for name in rules wf runs clog; do echo fail > "$WORK/$name.rc"; done
@@ -207,7 +209,8 @@ $(jq -r --arg c "$ctx" '[.[]|select(.type=="required_status_checks")
 EOF
   fi
   if [ "$(st runs)" = ok ]; then
-    obs="$(jq -r --arg c "$ctx" '[.check_runs[]|select(.name==$c)|.app.id // "none"]
+    # -n + inputs unions runs across all --paginate page documents.
+    obs="$(jq -rn --arg c "$ctx" '[inputs.check_runs[]?|select(.name==$c)|.app.id // "none"]
       | unique|map(tostring)|join(",") | if . == "" then "none" else . end' "$WORK/runs.json")"
   fi
   if [ "$pres" = unknown ]; then emit "required_checks.context.$ctx" UNKNOWN "effective rules unavailable" "$BASE"

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -46,6 +46,7 @@ case "$path" in
   repos/*/rules/branches/*) f=rules.json ;;
   repos/*/rulesets/*) f="rs-repo-${path##*/}.json" ;;
   orgs/*/rulesets/*) f="rs-org-${path##*/}.json" ;;
+  orgs/*) f=org.json ;;
   repos/*/actions/permissions/workflow) f=workflow.json ;;
   repos/*/commits/*/check-runs*) f=checkruns.json ;;
   repos/*/contents/.github/workflows/*) p="${path%%\?*}"; f="wff-${p##*/}" ;;
@@ -87,6 +88,7 @@ team_rules() { # fully hardened; binds every context to app id $1
     "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
 }
 mk_repo() { printf '{"default_branch":"main","owner":{"login":"o","type":"%s"},"private":%s%s}\n' "$1" "$2" "${3:-}" > "$GS_FIX/repo.json"; }
+mk_org() { printf '{"login":"o"%s}\n' "${1:-}" > "$GS_FIX/org.json"; }
 mk_rs() { printf '{"id":%s,"bypass_actors":%s}\n' "$1" "$3" > "$GS_FIX/rs-$2-$1.json"; }
 mk_wf() { printf '{"default_workflow_permissions":"%s","can_approve_pull_request_reviews":%s}\n' "$1" "$2" > "$GS_FIX/workflow.json"; }
 mk_runs() {
@@ -108,17 +110,13 @@ baseline() { # live-like template repository on the solo minimum
   solo_rules
   mk_rs 101 repo "$RRB"
   mk_runs quality:15368 task-ritual:15368 scaffold-self-check:15368 copilot-surface:15368
-  mk_wf read false
-  mk_repo User false
-  mk_marker unknown
-  mk_co '# CUSTOMIZE: replace @owner'
+  mk_wf read false; mk_repo User false
+  mk_marker unknown; mk_co '# CUSTOMIZE: replace @owner'
 }
 team_green() { # hardened adopted fixtures that satisfy team intent end to end
   baseline
-  team_rules 15368
-  mk_rs 101 repo '[]'
-  mk_marker abc123
-  mk_co '# reviewed owners'
+  team_rules 15368; mk_rs 101 repo '[]'
+  mk_marker abc123; mk_co '# reviewed owners'
 }
 
 run() { rc=0; out="$(bash "$SENSOR" "$@" 2>&1)" || rc=$?; }
@@ -169,9 +167,8 @@ rce "stronger settings stay healthy for solo" 0
 
 baseline
 jq '. + [{"type":"pull_request","parameters":{"required_approving_review_count":2,
-  "dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,
-  "require_last_push_approval":false,"required_review_thread_resolution":false},
-  "ruleset_source_type":"Organization","ruleset_source":"orgname","ruleset_id":900}]' \
+  "dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,"require_last_push_approval":false,
+  "required_review_thread_resolution":false},"ruleset_source_type":"Organization","ruleset_source":"orgname","ruleset_id":900}]' \
   "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
 mk_rs 900 org '[{"actor_id":42,"actor_type":"Integration","bypass_mode":"always"}]'
 run -R o/r --profile solo
@@ -247,25 +244,29 @@ rce "unresolved codeowners does not gate solo" 0
 chk "solo still shows codeowners OFF" "^codeowners\.tuning${T}OFF"
 
 baseline
-mk_repo Organization false
+mk_repo Organization true
 run -R o/r --profile solo
-rce "org unresolved applicability gates the declared profile" 3
-chk "unproven merge queue is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE"
-mk_repo Organization true ',"plan":{"name":"free"}'
+rce "private org without plan evidence fails closed" 3
+chk "unavailable org plan is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
+mk_org ''; run -R o/r --profile solo
+rce "plan-less org payload stays unknown" 3
+chk "absent plan field is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
+mk_org ',"plan":{"name":"free"}'
+jq '. + [{"type":"merge_queue","parameters":{},"ruleset_source_type":"Repository","ruleset_source":"o/r","ruleset_id":101}]' "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
+mk_wfdir ci.yml; mk_wff ci.yml 'on: [pull_request, merge_group]'
 run -R o/r --profile solo
-rce "proven ineligibility stays healthy" 0
-chk "proven ineligibility is N/A" "^merge_queue\.applicability${T}N/A${T}private repository on free plan"
-jq '. + [{"type":"merge_queue","parameters":{},"ruleset_source_type":"Repository",
-  "ruleset_source":"o/r","ruleset_id":101}]' \
-  "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
-mk_wfdir ci.yml lint.yml
-mk_wff ci.yml 'on: [pull_request, merge_group]'
-mk_wff lint.yml '# merge_group planned someday'
-run -R o/r --profile solo
-rce "merge queue with complete evidence stays healthy" 0
+rce "proven ineligibility outranks rule and coverage" 0
+chk "ineligible org stays N/A despite rule" "^merge_queue\.applicability${T}N/A${T}private repository on free plan"
+if grep -q '^api orgs/o$' "$GH_CALLS"; then t_ok "org plan evidence read via GET /orgs/{owner}"; else t_fail "org plan evidence read via GET /orgs/{owner}"; fi
+mk_repo Organization false; run -R o/r --profile solo
+rce "public org repository is eligible by repository evidence" 0
 chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
-mk_wff ci.yml 'on: [pull_request] # merge_group only in this comment'
+mk_wfdir ci.yml lint.yml; mk_wff ci.yml $'on:\n  merge_group:\n    branches: [main]'
+mk_wff lint.yml $'on: [push]\njobs:\n  x:\n    steps:\n      - run: echo merge_group ready\nenv:\n  NOTE: merge_group'
 run -R o/r --profile solo
+rce "genuine trigger structure is the only coverage evidence" 0
+chk "block-map trigger counts once; token noise never counts" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
+mk_wff ci.yml 'on: [pull_request] # merge_group only in this comment'; run -R o/r --profile solo
 rce "merge_queue rule without merge_group coverage exits 3" 3
 chk "uncovered merge_queue rule is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE${T}merge_queue rule active without observed merge_group workflow coverage"
 runf "contents/.github/workflows?" -R o/r --profile solo
@@ -274,11 +275,12 @@ chk "unreadable listing is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}m
 runf "workflows/ci.yml" -R o/r --profile solo
 rce "workflow content failure exits 3" 3
 chk "unreadable workflow is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}merge_group workflow coverage evidence unavailable"
-rm -f "$GS_FIX/wfdir.json"
-run -R o/r --profile solo
+rm -f "$GS_FIX/wfdir.json"; run -R o/r --profile solo
 rce "absent workflow directory cannot certify coverage" 3
 chk "absent workflows are UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE${T}merge_queue rule active without observed merge_group workflow coverage"
-mk_repo Organization false
+solo_rules; run -R o/r --profile solo
+rce "org unresolved applicability gates the declared profile" 3
+chk "eligible org without rule is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE${T}eligible repository without a merge_queue rule"
 runf "rules/branches" -R o/r --profile solo
 rce "org effective-rule failure exits 3" 3
 chk "org merge queue UNKNOWN without effective rules" "^merge_queue\.applicability${T}UNKNOWN${T}effective rules unavailable"

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -48,6 +48,8 @@ case "$path" in
   orgs/*/rulesets/*) f="rs-org-${path##*/}.json" ;;
   repos/*/actions/permissions/workflow) f=workflow.json ;;
   repos/*/commits/*/check-runs*) f=checkruns.json ;;
+  repos/*/contents/.github/workflows/*) p="${path%%\?*}"; f="wff-${p##*/}" ;;
+  repos/*/contents/.github/workflows*) f=wfdir.json ;;
   repos/*/contents/SCAFFOLD-CHANGELOG.md*) f=changelog.raw ;;
   repos/*/contents/.github/CODEOWNERS*) f=codeowners.raw ;;
   repos/*) f=repo.json ;;
@@ -97,6 +99,8 @@ mk_runs() {
 }
 mk_marker() { printf '# log\n<!-- scaffold-version: repo=o/r sha=%s date=x -->\n' "$1" > "$GS_FIX/changelog.raw"; }
 mk_co() { printf '%s\n/.github/docs/agreements/ @owner\n' "$1" > "$GS_FIX/codeowners.raw"; }
+mk_wfdir() { local out="" sep="" n; for n in "$@"; do out="$out$sep{\"name\":\"$n\",\"type\":\"file\"}"; sep=","; done; printf '[%s]\n' "$out" > "$GS_FIX/wfdir.json"; }
+mk_wff() { printf '%s\n' "$2" > "$GS_FIX/wff-$1"; }
 
 RRB='[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"pull_request"}]'
 baseline() { # live-like template repository on the solo minimum
@@ -245,16 +249,39 @@ chk "solo still shows codeowners OFF" "^codeowners\.tuning${T}OFF"
 baseline
 mk_repo Organization false
 run -R o/r --profile solo
-rce "org without eligibility evidence stays healthy" 0
+rce "org unresolved applicability gates the declared profile" 3
 chk "unproven merge queue is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE"
 mk_repo Organization true ',"plan":{"name":"free"}'
 run -R o/r --profile solo
+rce "proven ineligibility stays healthy" 0
 chk "proven ineligibility is N/A" "^merge_queue\.applicability${T}N/A${T}private repository on free plan"
 jq '. + [{"type":"merge_queue","parameters":{},"ruleset_source_type":"Repository",
   "ruleset_source":"o/r","ruleset_id":101}]' \
   "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
+mk_wfdir ci.yml lint.yml
+mk_wff ci.yml 'on: [pull_request, merge_group]'
+mk_wff lint.yml '# merge_group planned someday'
 run -R o/r --profile solo
-chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active"
+rce "merge queue with complete evidence stays healthy" 0
+chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
+mk_wff ci.yml 'on: [pull_request] # merge_group only in this comment'
+run -R o/r --profile solo
+rce "merge_queue rule without merge_group coverage exits 3" 3
+chk "uncovered merge_queue rule is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE${T}merge_queue rule active without observed merge_group workflow coverage"
+runf "contents/.github/workflows?" -R o/r --profile solo
+rce "workflow listing failure exits 3" 3
+chk "unreadable listing is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}merge_group workflow coverage evidence unavailable"
+runf "workflows/ci.yml" -R o/r --profile solo
+rce "workflow content failure exits 3" 3
+chk "unreadable workflow is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}merge_group workflow coverage evidence unavailable"
+rm -f "$GS_FIX/wfdir.json"
+run -R o/r --profile solo
+rce "absent workflow directory cannot certify coverage" 3
+chk "absent workflows are UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE${T}merge_queue rule active without observed merge_group workflow coverage"
+mk_repo Organization false
+runf "rules/branches" -R o/r --profile solo
+rce "org effective-rule failure exits 3" 3
+chk "org merge queue UNKNOWN without effective rules" "^merge_queue\.applicability${T}UNKNOWN${T}effective rules unavailable"
 
 baseline
 runf "rules/branches" -R o/r --profile solo

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -35,6 +35,7 @@ path=""
 while [ $# -gt 0 ]; do
   case "$1" in
     -H) shift 2 ;;
+    --paginate) shift ;;
     *) path="$1"; shift ;;
   esac
 done
@@ -124,6 +125,7 @@ chk() { if printf '%s\n' "$out" | grep -Eq "$2"; then t_ok "$1"; else t_fail "$1
 baseline
 run -R o/r --profile solo
 rce "solo baseline is healthy" 0
+if grep -q -- '--paginate repos/o/r/commits/main/check-runs?filter=latest&per_page=100' "$GH_CALLS"; then t_ok "check-run evidence is paginated and latest-filtered"; else t_fail "check-run evidence is paginated and latest-filtered"; fi
 chk "default branch discovered" "^repository\.default_branch${T}ACTIVE${T}main$"
 chk "declared profile echoed" "^governance\.profile${T}ACTIVE${T}solo$"
 chk "approval count bypass-qualified" "^pull_request\.required_approving_review_count${T}ACTIVE${T}count=1 bypass=RepositoryRole:5:pull_request$"
@@ -197,6 +199,19 @@ mk_runs quality:15368 quality:222 task-ritual:15368 scaffold-self-check:15368 co
 run -R o/r --profile team
 rce "ambiguous issuers exit 3" 3
 chk "multiple app ids are UNCHECKABLE" "^required_check_source\.quality${T}UNCHECKABLE${T}multiple issuing app ids: 222,15368$"
+
+team_green
+printf '%s\n%s\n' \
+  '{"check_runs":[{"name":"task-ritual","app":{"id":15368}},{"name":"scaffold-self-check","app":{"id":15368}},{"name":"copilot-surface","app":{"id":15368}}]}' \
+  '{"check_runs":[{"name":"quality","app":{"id":15368}}]}' > "$GS_FIX/checkruns.json"
+run -R o/r --profile team
+rce "paginated check-run evidence stays healthy" 0
+chk "runs found only on a later page are observed" "^required_check_source\.quality${T}ACTIVE${T}configured=15368 observed=15368$"
+printf '%s\n%s\n' '{"check_runs":[{"name":"quality","app":{"id":15368}}]}' \
+  '{"check_runs":[{"name":"quality","app":{"id":222}}]}' > "$GS_FIX/checkruns.json"
+run -R o/r --profile team
+rce "cross-page issuer conflict exits 3" 3
+chk "app ids union across pages before the source ruling" "^required_check_source\.quality${T}UNCHECKABLE${T}multiple issuing app ids: 222,15368$"
 
 baseline
 run -R o/r --profile solo --checks quality,ghost

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# test-governance-status.sh — fixture wall for the read-only governance
+# sensor: profiles, effective-rule aggregation, bypass qualification,
+# evidence states, exit precedence, and a GET-only gh shim that hard-fails
+# any mutating invocation.
+
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/lib.sh"
+
+SENSOR="$ROOT/.github/scripts/governance-status.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/governance-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin" "$WORK/fix" "$WORK/cwd"
+export GH_CALLS="$WORK/gh.log" GS_FIX="$WORK/fix"
+T="$(printf '\t')"
+
+cat > "$WORK/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$GH_CALLS"
+for a in "$@"; do
+  case "$a" in
+    -X*|--method*|-f*|-F*|--field*|--raw-field*|--input*|POST|PUT|PATCH|DELETE)
+      printf 'MUTATION %s\n' "$*" >> "$GH_CALLS"
+      echo "gh stub: mutating invocation refused" >&2
+      exit 64 ;;
+  esac
+done
+[ "${1:-}" = api ] || { printf 'MUTATION %s\n' "$*" >> "$GH_CALLS"; exit 64; }
+shift
+path=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -H) shift 2 ;;
+    *) path="$1"; shift ;;
+  esac
+done
+for frag in ${GS_FAIL:-}; do
+  case "$path" in *"$frag"*) echo "gh: HTTP 500 (simulated)" >&2; exit 1 ;; esac
+done
+case "$path" in
+  repos/*/rules/branches/*) f=rules.json ;;
+  repos/*/rulesets/*) f="rs-repo-${path##*/}.json" ;;
+  orgs/*/rulesets/*) f="rs-org-${path##*/}.json" ;;
+  repos/*/actions/permissions/workflow) f=workflow.json ;;
+  repos/*/commits/*/check-runs*) f=checkruns.json ;;
+  repos/*/contents/SCAFFOLD-CHANGELOG.md*) f=changelog.raw ;;
+  repos/*/contents/.github/CODEOWNERS*) f=codeowners.raw ;;
+  repos/*) f=repo.json ;;
+  *) echo "gh stub: no fixture mapped for '$path'" >&2; exit 64 ;;
+esac
+[ -f "$GS_FIX/$f" ] || { echo "gh: Not Found (HTTP 404)" >&2; exit 1; }
+cat "$GS_FIX/$f"
+STUB
+chmod +x "$WORK/bin/gh"
+PATH="$WORK/bin:$PATH"
+export PATH
+
+solo_rules() {
+  cat > "$GS_FIX/rules.json" <<'J'
+[{"type":"pull_request","parameters":{"required_approving_review_count":1,
+"dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,
+"require_last_push_approval":false,"required_review_thread_resolution":false},
+"ruleset_source_type":"Repository","ruleset_source":"o/r","ruleset_id":101},
+{"type":"required_status_checks","parameters":{
+"strict_required_status_checks_policy":false,"required_status_checks":[
+{"context":"quality"},{"context":"task-ritual"},
+{"context":"scaffold-self-check"},{"context":"copilot-surface"}]},
+"ruleset_source_type":"Repository","ruleset_source":"o/r","ruleset_id":101}]
+J
+}
+team_rules() { # fully hardened; binds every context to app id $1
+  solo_rules
+  jq --argjson app "$1" '
+    (.[]|select(.type=="pull_request").parameters) |=
+      (.dismiss_stale_reviews_on_push=true | .require_code_owner_review=true
+       | .require_last_push_approval=true | .required_review_thread_resolution=true)
+    | (.[]|select(.type=="required_status_checks").parameters) |=
+      (.strict_required_status_checks_policy=true
+       | .required_status_checks |= map(.integration_id=$app))' \
+    "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
+}
+mk_repo() { printf '{"default_branch":"main","owner":{"login":"o","type":"%s"},"private":%s%s}\n' "$1" "$2" "${3:-}" > "$GS_FIX/repo.json"; }
+mk_rs() { printf '{"id":%s,"bypass_actors":%s}\n' "$1" "$3" > "$GS_FIX/rs-$2-$1.json"; }
+mk_wf() { printf '{"default_workflow_permissions":"%s","can_approve_pull_request_reviews":%s}\n' "$1" "$2" > "$GS_FIX/workflow.json"; }
+mk_runs() {
+  local out="" sep="" p
+  for p in "$@"; do
+    out="$out$sep{\"name\":\"${p%%:*}\",\"app\":{\"id\":${p##*:},\"slug\":\"github-actions\"}}"
+    sep=","
+  done
+  printf '{"total_count":%s,"check_runs":[%s]}\n' "$#" "$out" > "$GS_FIX/checkruns.json"
+}
+mk_marker() { printf '# log\n<!-- scaffold-version: repo=o/r sha=%s date=x -->\n' "$1" > "$GS_FIX/changelog.raw"; }
+mk_co() { printf '%s\n/.github/docs/agreements/ @owner\n' "$1" > "$GS_FIX/codeowners.raw"; }
+
+RRB='[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"pull_request"}]'
+baseline() { # live-like template repository on the solo minimum
+  rm -f "$GS_FIX"/*
+  solo_rules
+  mk_rs 101 repo "$RRB"
+  mk_runs quality:15368 task-ritual:15368 scaffold-self-check:15368 copilot-surface:15368
+  mk_wf read false
+  mk_repo User false
+  mk_marker unknown
+  mk_co '# CUSTOMIZE: replace @owner'
+}
+team_green() { # hardened adopted fixtures that satisfy team intent end to end
+  baseline
+  team_rules 15368
+  mk_rs 101 repo '[]'
+  mk_marker abc123
+  mk_co '# reviewed owners'
+}
+
+run() { rc=0; out="$(bash "$SENSOR" "$@" 2>&1)" || rc=$?; }
+runf() { local f="$1"; shift; rc=0; out="$(GS_FAIL="$f" bash "$SENSOR" "$@" 2>&1)" || rc=$?; }
+rce() { if [ "$rc" -eq "$2" ]; then t_ok "$1"; else t_fail "$1 (rc=$rc)"; printf '%s\n' "$out" | sed 's/^/    # /'; fi; }
+chk() { if printf '%s\n' "$out" | grep -Eq "$2"; then t_ok "$1"; else t_fail "$1 (missing: $2)"; printf '%s\n' "$out" | sed 's/^/    # /'; fi; }
+
+baseline
+run -R o/r --profile solo
+rce "solo baseline is healthy" 0
+chk "default branch discovered" "^repository\.default_branch${T}ACTIVE${T}main$"
+chk "declared profile echoed" "^governance\.profile${T}ACTIVE${T}solo$"
+chk "approval count bypass-qualified" "^pull_request\.required_approving_review_count${T}ACTIVE${T}count=1 bypass=RepositoryRole:5:pull_request$"
+chk "solo shows stale-review state without gating" "^pull_request\.dismiss_stale_reviews${T}OFF"
+chk "context bypass-qualified" "^required_checks\.context\.quality${T}ACTIVE${T}required by effective rules bypass=RepositoryRole:5:pull_request$"
+chk "check source informational for solo" "^required_check_source\.quality${T}N/A${T}configured=none observed=15368"
+chk "actions permissions read" "^actions\.default_workflow_permissions${T}ACTIVE${T}read$"
+chk "actions approve-reviews false" "^actions\.can_approve_pull_request_reviews${T}ACTIVE${T}false$"
+chk "template codeowners not applicable" "^codeowners\.tuning${T}N/A${T}template tree"
+chk "user-owned merge queue not applicable" "^merge_queue\.applicability${T}N/A${T}owner_type=User"
+chk "bypass ruleset summarized" "^bypass\.ruleset\.101${T}ACTIVE${T}source=Repository:o/r actors=1$"
+chk "bypass actor enumerated" "^bypass\.ruleset\.101\.actor\.1${T}ACTIVE${T}actor_type=RepositoryRole actor_id=5 bypass_mode=pull_request$"
+if printf '%s\n' "$out" | awk -F"$T" 'NF != 3 { bad = 1 } END { exit bad }'; then t_ok "every line has exactly three tab-separated fields"; else t_fail "every line has exactly three tab-separated fields"; fi
+if [ "$(printf '%s\n' "$out" | head -n 2 | cut -f1 | tr '\n' ' ')" = "repository.default_branch governance.profile " ]; then t_ok "key order is fixed"; else t_fail "key order is fixed"; fi
+first="$out"
+run -R o/r --profile solo
+if [ "$first" = "$out" ]; then t_ok "output is deterministic across runs"; else t_fail "output is deterministic across runs"; fi
+
+run -R o/r
+rce "omitted profile exits 3, never guessed" 3
+chk "omitted profile reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+
+run -R o/r --profile team
+rce "solo baseline fails team intent" 1
+chk "team gap: stale reviews OFF" "^pull_request\.dismiss_stale_reviews${T}OFF${T}false"
+chk "team gap: unbound check source OFF" "^required_check_source\.quality${T}OFF${T}configured=none observed=15368$"
+
+team_green
+run -R o/r --profile team
+rce "fully hardened team is healthy" 0
+chk "bound check source matches observation" "^required_check_source\.quality${T}ACTIVE${T}configured=15368 observed=15368$"
+chk "tuned codeowners ACTIVE" "^codeowners\.tuning${T}ACTIVE"
+chk "no bypass suffix without actors" "^pull_request\.required_approving_review_count${T}ACTIVE${T}count=1$"
+chk "empty bypass list stated" "^bypass\.ruleset\.101${T}ACTIVE${T}source=Repository:o/r actors=0$"
+run -R o/r --profile solo
+rce "stronger settings stay healthy for solo" 0
+
+baseline
+jq '. + [{"type":"pull_request","parameters":{"required_approving_review_count":2,
+  "dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,
+  "require_last_push_approval":false,"required_review_thread_resolution":false},
+  "ruleset_source_type":"Organization","ruleset_source":"orgname","ruleset_id":900}]' \
+  "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
+mk_rs 900 org '[{"actor_id":42,"actor_type":"Integration","bypass_mode":"always"}]'
+run -R o/r --profile solo
+rce "parent ruleset aggregation stays healthy" 0
+chk "strongest approval threshold wins across sources" "^pull_request\.required_approving_review_count${T}ACTIVE${T}count=2 bypass=RepositoryRole:5:pull_request,Integration:42:always$"
+chk "organization bypass enumerated" "^bypass\.ruleset\.900${T}ACTIVE${T}source=Organization:orgname actors=1$"
+if grep -q 'orgs/orgname/rulesets/900' "$GH_CALLS"; then t_ok "organization ruleset detail fetched via orgs endpoint"; else t_fail "organization ruleset detail fetched via orgs endpoint"; fi
+
+baseline
+runf "rulesets/101" -R o/r --profile solo
+rce "failed ruleset detail read exits 3" 3
+chk "failed detail read is UNKNOWN, never empty" "^bypass\.ruleset\.101${T}UNKNOWN${T}ruleset detail unavailable"
+chk "controls flag unknown bypass evidence" "^pull_request\.required_approving_review_count${T}ACTIVE${T}count=1 bypass=unknown$"
+
+team_green
+team_rules 99999
+run -R o/r --profile team
+rce "configured-observed source mismatch fails team" 1
+chk "source mismatch is OFF" "^required_check_source\.quality${T}OFF${T}configured=99999 observed=15368$"
+
+team_green
+mk_runs quality:15368 task-ritual:15368 scaffold-self-check:15368
+run -R o/r --profile team
+rce "absent check run exits 3" 3
+chk "absent run is UNCHECKABLE" "^required_check_source\.copilot-surface${T}UNCHECKABLE${T}.*no check run observed"
+
+team_green
+mk_runs quality:15368 quality:222 task-ritual:15368 scaffold-self-check:15368 copilot-surface:15368
+run -R o/r --profile team
+rce "ambiguous issuers exit 3" 3
+chk "multiple app ids are UNCHECKABLE" "^required_check_source\.quality${T}UNCHECKABLE${T}multiple issuing app ids: 222,15368$"
+
+baseline
+run -R o/r --profile solo --checks quality,ghost
+rce "missing requested context fails solo" 1
+chk "missing context is OFF" "^required_checks\.context\.ghost${T}OFF${T}not required by effective rules$"
+run -R o/r --profile team --checks quality,ghost
+rce "UNCHECKABLE evidence outranks OFF" 3
+
+team_green
+mk_co '# CUSTOMIZE: replace @owner'
+run -R o/r --profile team
+rce "adopted unresolved codeowners fails team" 1
+chk "unresolved CUSTOMIZE is OFF" "^codeowners\.tuning${T}OFF${T}adopted tree with unresolved CUSTOMIZE ownership$"
+rm -f "$GS_FIX/codeowners.raw"
+run -R o/r --profile team
+rce "absent codeowners on adopted tree fails team" 1
+chk "absent codeowners is OFF" "^codeowners\.tuning${T}OFF${T}adopted tree without \.github/CODEOWNERS$"
+runf "contents/.github/CODEOWNERS" -R o/r --profile team
+rce "unreadable codeowners exits 3" 3
+chk "unreadable codeowners is UNKNOWN" "^codeowners\.tuning${T}UNKNOWN${T}CODEOWNERS evidence unreadable$"
+rm -f "$GS_FIX/changelog.raw"
+run -R o/r --profile team
+rce "missing scaffold marker exits 3" 3
+chk "missing marker is UNKNOWN" "^codeowners\.tuning${T}UNKNOWN${T}scaffold marker unavailable"
+baseline
+mk_marker abc123
+run -R o/r --profile solo
+rce "unresolved codeowners does not gate solo" 0
+chk "solo still shows codeowners OFF" "^codeowners\.tuning${T}OFF"
+
+baseline
+mk_repo Organization false
+run -R o/r --profile solo
+rce "org without eligibility evidence stays healthy" 0
+chk "unproven merge queue is UNCHECKABLE" "^merge_queue\.applicability${T}UNCHECKABLE"
+mk_repo Organization true ',"plan":{"name":"free"}'
+run -R o/r --profile solo
+chk "proven ineligibility is N/A" "^merge_queue\.applicability${T}N/A${T}private repository on free plan"
+jq '. + [{"type":"merge_queue","parameters":{},"ruleset_source_type":"Repository",
+  "ruleset_source":"o/r","ruleset_id":101}]' \
+  "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
+run -R o/r --profile solo
+chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active"
+
+baseline
+runf "rules/branches" -R o/r --profile solo
+rce "effective-rules failure exits 3" 3
+chk "rule facts become UNKNOWN" "^pull_request\.required_approving_review_count${T}UNKNOWN${T}effective rules unavailable$"
+runf "actions/permissions" -R o/r --profile solo
+rce "actions failure exits 3" 3
+chk "actions posture UNKNOWN on failure" "^actions\.default_workflow_permissions${T}UNKNOWN"
+runf "check-runs" -R o/r --profile team
+rce "check-run failure exits 3 for team" 3
+chk "check source UNKNOWN on API failure" "^required_check_source\.quality${T}UNKNOWN${T}.*check-run evidence unavailable"
+runf "check-runs" -R o/r --profile solo
+rce "check-run failure does not gate solo" 0
+chk "solo source detail shows unknown observation" "^required_check_source\.quality${T}N/A${T}configured=none observed=unknown"
+rm -f "$GS_FIX/repo.json"
+run -R o/r --profile solo
+rce "repository metadata failure exits 3" 3
+chk "default branch UNKNOWN on failure" "^repository\.default_branch${T}UNKNOWN"
+
+baseline
+runf "actions/permissions" -R o/r --profile team
+rce "missing evidence outranks OFF requirements" 3
+
+run
+rce "missing -R is a usage error" 2
+run -R o/r --profile pirate
+rce "invalid profile is a usage error" 2
+run -R o/r --bogus
+rce "unknown flag is a usage error" 2
+run -R norepo --profile solo
+rce "malformed repository is a usage error" 2
+run -R o/r --profile solo --checks ,,,
+rce "degenerate --checks list is a usage error" 2
+
+if grep -q '^MUTATION' "$GH_CALLS"; then t_fail "sensor performed GET-only gh calls"; grep '^MUTATION' "$GH_CALLS" | sed 's/^/    # /'; else t_ok "sensor performed GET-only gh calls"; fi
+if grep -Ev '^api ' "$GH_CALLS" | grep -q .; then t_fail "every gh invocation is a plain gh api read"; else t_ok "every gh invocation is a plain gh api read"; fi
+rc=0
+"$WORK/bin/gh" api -X DELETE repos/o/r/rulesets/1 >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 64 ] && grep -q '^MUTATION' "$GH_CALLS"; then t_ok "shim wall refuses mutating invocations"; else t_fail "shim wall refuses mutating invocations (rc=$rc)"; fi
+wall=ok
+for bad in --method=DELETE -XDELETE -fk=v -F=k=v --field=k=v --raw-field=k=v --input=p.json PATCH; do
+  rc=0; "$WORK/bin/gh" api "$bad" repos/o/r >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 64 ] || wall="leaks $bad"
+done
+if [ "$wall" = ok ]; then t_ok "shim wall refuses equals-form and attached mutating flags"; else t_fail "shim wall refuses equals-form and attached mutating flags ($wall)"; fi
+baseline
+(cd "$WORK/cwd" && bash "$SENSOR" -R o/r --profile solo >/dev/null 2>&1)
+if [ -z "$(ls -A "$WORK/cwd")" ]; then t_ok "sensor persists no profile or file state"; else t_fail "sensor persists no profile or file state"; fi
+
+t_summary

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -243,24 +243,22 @@ run -R o/r --profile solo
 rce "unresolved codeowners does not gate solo" 0
 chk "solo still shows codeowners OFF" "^codeowners\.tuning${T}OFF"
 
-baseline
-mk_repo Organization true
-run -R o/r --profile solo
+baseline; mk_repo Organization true; run -R o/r --profile solo
 rce "private org without plan evidence fails closed" 3
 chk "unavailable org plan is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
-mk_org ''; run -R o/r --profile solo
-rce "plan-less org payload stays unknown" 3
-chk "absent plan field is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
-mk_org ',"plan":{"name":"free"}'
+mk_org ''; run -R o/r --profile solo; rce "plan-less org payload stays unknown" 3; chk "absent plan field is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
 jq '. + [{"type":"merge_queue","parameters":{},"ruleset_source_type":"Repository","ruleset_source":"o/r","ruleset_id":101}]' "$GS_FIX/rules.json" > "$GS_FIX/r.tmp" && mv "$GS_FIX/r.tmp" "$GS_FIX/rules.json"
 mk_wfdir ci.yml; mk_wff ci.yml 'on: [pull_request, merge_group]'
-run -R o/r --profile solo
-rce "proven ineligibility outranks rule and coverage" 0
-chk "ineligible org stays N/A despite rule" "^merge_queue\.applicability${T}N/A${T}private repository on free plan"
+mk_org ',"plan":{"name":"unknown"}'; run -R o/r --profile solo
+rce "unrecognized org plan fails closed" 3; chk "unrecognized plan is UNKNOWN" "^merge_queue\.applicability${T}UNKNOWN${T}organization plan evidence unavailable"
+for plan in free team; do
+  mk_org ",\"plan\":{\"name\":\"$plan\"}"; run -R o/r --profile solo
+  rce "private org $plan plan is provably ineligible" 0; chk "$plan plan stays N/A despite rule and coverage" "^merge_queue\.applicability${T}N/A${T}private repository plan=$plan is ineligible"
+done
+mk_org ',"plan":{"name":"enterprise"}'; run -R o/r --profile solo
+rce "private enterprise org is eligible with complete evidence" 0; chk "enterprise org reaches ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
 if grep -q '^api orgs/o$' "$GH_CALLS"; then t_ok "org plan evidence read via GET /orgs/{owner}"; else t_fail "org plan evidence read via GET /orgs/{owner}"; fi
-mk_repo Organization false; run -R o/r --profile solo
-rce "public org repository is eligible by repository evidence" 0
-chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
+mk_repo Organization false; run -R o/r --profile solo; rce "public org repository is eligible by repository evidence" 0; chk "effective merge_queue rule is ACTIVE" "^merge_queue\.applicability${T}ACTIVE${T}merge_queue rule active.*merge_group coverage in 1 workflow"
 mk_wfdir ci.yml lint.yml; mk_wff ci.yml $'on:\n  merge_group:\n    branches: [main]'
 mk_wff lint.yml $'on: [push]\njobs:\n  x:\n    steps:\n      - run: echo merge_group ready\nenv:\n  NOTE: merge_group'
 run -R o/r --profile solo


### PR DESCRIPTION
Closes #92

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/92#issuecomment-5308640527

## Summary

Adds `.github/scripts/governance-status.sh`, a GET-only Bash 3.2 sensor that evaluates effective default-branch governance against explicit `--profile solo|team` intent. It aggregates effective pull-request and required-check rules across active sources, reports bypass actors, observed check issuers, Actions posture, CODEOWNERS tuning, and merge-queue applicability as deterministic tab-separated `key/state/detail` rows, and preserves exit precedence 2 > 3 > 1 > 0.

Organization merge-queue reporting now fails closed: private repositories require recognized organization plan evidence (`free`/`team` are proven ineligible; `enterprise` is eligible), public organization repositories are eligible from repository evidence, and ACTIVE requires an effective merge-queue rule plus a genuine top-level `merge_group` workflow trigger. Missing, unreadable, or unrecognized plan evidence and incomplete rule/coverage evidence remain UNKNOWN/UNCHECKABLE with exit 3.

## Red-to-green chronology

1. Initial fixture wall `f51a932` preceded sensor implementation `4576711`; follow-up `c2bcd63` fixed check-run pagination/latest filtering.
2. First merge-queue rework: tests-only `67d9a89` -> [expected-red run 31980745246](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31980745246) -> implementation `ca092dc` -> [green run 31981259537](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31981259537).
3. Round-2 eligibility/trigger fixtures: tests-only `c1613eb` -> [expected-red run 31983338586](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31983338586) (`102 case(s), 8 failed`) -> salvaged production commit `8754042` -> [green run 31984912295](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31984912295).
4. Official Rubber Duck then found that private Team-plan organization repositories were incorrectly treated as eligible. GitHub's [merge-queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) and [GA announcement](https://github.blog/changelog/2023-07-12-pull-request-merge-queue-is-now-generally-available) establish that private repositories require GitHub Enterprise Cloud.
5. Rubber Duck rework: tests-only `2fab045` -> [expected-red run 31985589998](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31985589998) -> implementation `c00c930` -> [implementation green run 31985646001](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31985646001) -> [authoritative follow-up run 31985885139](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31985885139), with all five checks successful at the unchanged head `c00c930`. The evidence-only body sync then produced [post-edit run 31986282716](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31986282716), also 5/5 successful at the same head.

## Evidence

| Criterion | Evidence (command / link) | Result |
|---|---|---|
| Tests first with fixed fixtures for all listed scenarios | Tests-only commits `f51a932`, `67d9a89`, `c1613eb`, and `2fab045` precede their implementations; latest focused wall: `bash .github/scripts/tests/run-tests.sh governance-status` -> `108 case(s), 0 failed` | pass |
| `-R`, explicit profile, optional contexts; omitted profile fails closed | Live omitted-profile probe -> exit 3 and `governance.profile UNKNOWN`; fixture coverage passes | pass |
| Default branch discovery and aggregation across every effective source | Live `repository.default_branch ACTIVE main`; fixtures prove split/duplicate rule aggregation and strongest approval threshold | pass |
| Ruleset detail and bypass actors | Repo/org ruleset detail fixtures enumerate actors; failed detail reads become UNKNOWN, never an empty list | pass |
| Stable deterministic three-field output | Fixtures verify exactly three tab-separated fields, fixed key order, and byte-deterministic output | pass |
| Required-check issuer semantics | Fixtures cover absent/ambiguous runs as UNCHECKABLE, mismatch as OFF, API failure as UNKNOWN, solo N/A, team-required binding, pagination, and latest filtering | pass |
| CODEOWNERS states | Fixtures cover template `sha=unknown` N/A, adopted unresolved OFF, tuned ACTIVE, unreadable UNKNOWN; live result is N/A | pass |
| Merge-queue applicability and coverage | User-owned N/A; private `free`/`team` plans N/A; private `enterprise` and public org eligible; missing/unreadable/unrecognized plan UNKNOWN; ACTIVE requires rule plus genuine `merge_group`; incomplete evidence exits 3 | pass |
| Exit precedence and visible bypass qualification | Fixtures prove 0/1/2/3 precedence and that bypass detail does not rewrite observed state | pass |
| GET-only, no persistence or mutation | The `gh` shim refuses mutating methods/flags and verifies every sensor invocation is a plain read; persistence fixture passes | pass |
| Bash 3.2 and approved size/ownership | macOS Bash 3.2-compatible constructs; `gh`, `jq`, `sed`, `awk`, `grep`, core utilities only; PR-base diff is exactly 649 additions, 0 deletions across the two owned paths | pass |
| Full Issue #92 Verification | `gh auth status` 0; focused wall 108/108; live solo exit 0 + all greps 0; omitted exit 3 + grep 0; team exit 1 + OFF grep 0; full suite `23 guard test file(s)` pass; repository ShellCheck and all listed `check-*.sh` commands exit 0 | pass |
| Final CI | [Implementation run 31985646001](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31985646001), authoritative [follow-up run 31985885139](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31985885139), and evidence [post-edit run 31986282716](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31986282716): `quality`, `task-ritual`, `scaffold-self-check`, `copilot-surface`, and `windows-launcher` all success at unchanged head `c00c930` | pass |

## Rubber Duck

- First official app-surface critique found one substantive defect after `8754042`: private Team-plan repositories were not recognized as provably ineligible. The finding was confirmed against official GitHub availability documentation and corrected tests-first.
- Final official critique of `8754042..c00c930` reported **PASS — no substantive concerns**. It traced free/team/enterprise/missing/unreadable/unrecognized plan paths, public/User behavior, genuine-trigger gating, GET-only behavior, and Bash 3.2 compatibility.

## Ownership and size

- `.github/scripts/governance-status.sh` — 315 additions
- `.github/scripts/tests/test-governance-status.sh` — 334 additions
- Total against PR base `99854a4`: **649 additions, 0 deletions**, exactly two owned paths; within the human-revised roughly-650 bound.

## Deviations

- The original roughly-400-line bound was exceeded. The requester revised the authority to roughly 650 in https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/92#issuecomment-5310300734; the current 649-line PR is within that authority.
- The PR was initially opened non-draft and the earliest implementation sequence did not preserve a tests-only red CI run. Later rework rounds preserve explicit tests-only red commits and run URLs; after remaining draft through rework and final audits, the repository owner approved ready-for-review in [Issue #92](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/92#issuecomment-5310933210) and on [PR #94](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/94#issuecomment-5310933312).
- The first worker-run audit reported PASS, but the independent supervisor audit found blocking merge-queue evidence and size gaps. Those gaps triggered the approved rework rather than being hidden.
- The sole resumed CLI worker exhausted quota after pushing tests-only `c1613eb`, leaving the authorized production fix uncommitted. A human-authorized replacement app worker verified and salvaged that exact payload as `8754042` without altering it.
- `8754042` passed the full wall and CI, but official Rubber Duck then found the private Team-plan eligibility defect. Work stopped before editing, the supervisor released the concrete in-scope fix, and a new tests-only red -> implementation -> green sequence (`2fab045` -> `c00c930`) corrected it.
- This worker was instructed not to post Task-issue comments. Claim/plan/dispatch/outcome ritual remains supervisor-owned.

## Task-contract audit status

The fresh independent custom reviewer audit first recorded an evidence-only **GAPS** result at https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/94#issuecomment-5310900360 because this body omitted authoritative follow-up run `31985885139`. After the evidence-only correction and successful post-edit run `31986282716`, the supervisor-owned fresh re-audit **PASSED with no gaps or advisories**: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/94#issuecomment-5310921253. The repository owner subsequently approved ready-for-review and administrator merge after final body-sync CI in [Issue #92](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/92#issuecomment-5310933210) and on [PR #94](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/94#issuecomment-5310933312); this step records readiness only, while merge remains separate.

## Follow-ups

None.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and linked above.
- [x] Diff stays inside the issue's File ownership paths.
- [x] Every Issue #92 Verification command was run verbatim and passed with expected live exit codes.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [x] Official Rubber Duck final critique passed with no substantive concerns.
- [x] Fresh independent custom reviewer audit passed with no gaps/advisories: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/94#issuecomment-5310921253.
- [ ] Record-before-report outcome comment (supervisor-owned; worker barred from issue comments).
- [x] All persistent artifacts are English-only.