### PR TITLE
Add opt-in source-bound ruleset profiles

### DIFF
--- a/.github/scripts/setup-ruleset.sh
+++ b/.github/scripts/setup-ruleset.sh
@@ -55,6 +55,8 @@ Options:
                            the ruleset never blocks merges until a human
                            reviews it and enables it.
   --name <name>            Ruleset name. Default: scaffold-branch-protection.
+  --profile <solo|team>    Persist explicit governance intent for a fresh
+                           ruleset. Team checks are bound to observed App IDs.
   --dry-run                Print the request JSON body to stdout and exit
                            without making any API call.
   -h, --help               Show this help and exit.
@@ -74,6 +76,7 @@ REPO=""
 CHECKS="quality,task-ritual,scaffold-self-check,copilot-surface"
 ENFORCEMENT="disabled"
 NAME="scaffold-branch-protection"
+PROFILE=""
 DRY_RUN="false"
 
 while [[ $# -gt 0 ]]; do
@@ -93,6 +96,12 @@ while [[ $# -gt 0 ]]; do
     --name)
       [[ -n "${2:-}" ]] || { echo "error: --name requires a value" >&2; exit 2; }
       NAME="$2"; shift 2 ;;
+    --profile)
+      case "${2:-}" in
+        solo|team) PROFILE="$2" ;;
+        *) echo "error: --profile must be 'solo' or 'team'" >&2; exit 2 ;;
+      esac
+      shift 2 ;;
     --dry-run)
       DRY_RUN="true"; shift ;;
     -h|--help)
@@ -150,7 +159,7 @@ PAYLOAD="$(jq -n \
     ]
   }')"
 
-if [[ "$DRY_RUN" == "true" ]]; then
+if [[ "$DRY_RUN" == "true" && "$PROFILE" != "team" ]]; then
   # stdout carries only the JSON body (pipeable to jq); notes go to stderr.
   echo "dry-run: request body for POST /repos/{owner}/{repo}/rulesets; no API call made." >&2
   printf '%s\n' "$PAYLOAD"
@@ -166,6 +175,55 @@ if [[ -z "$REPO" ]]; then
 fi
 [[ "$REPO" == */* ]] || { echo "error: repository must be owner/repo, got: $REPO" >&2; exit 2; }
 
+discover_team_payload() {
+  local repo_json default_branch check_runs app_id
+  if ! repo_json="$(gh api "repos/$REPO")"; then
+    echo "error: could not discover the default branch for $REPO." >&2
+    return 1
+  fi
+  if ! default_branch="$(printf '%s' "$repo_json" \
+    | jq -er '.default_branch | select(type == "string" and length > 0)')"; then
+    echo "error: repository metadata has no valid default branch." >&2
+    return 1
+  fi
+  if ! check_runs="$(gh api --paginate --slurp \
+    "repos/$REPO/commits/$default_branch/check-runs?filter=latest&per_page=100")"; then
+    echo "error: could not discover latest check runs for $default_branch." >&2
+    return 1
+  fi
+  # Each requested context must have one unique numeric issuer, and every
+  # context must share that issuer. Duplicate runs from the same App are safe.
+  if ! app_id="$(printf '%s' "$check_runs" | jq -er --arg checks "$CHECKS" '
+    ($checks | split(",") | map(gsub("^\\s+|\\s+$"; ""))
+      | map(select(length > 0))) as $contexts
+    | [$contexts[] as $context
+      | ([.[]?.check_runs[]? | select(.name == $context) | .app.id
+          | select(type == "number")] | unique) as $ids
+      | if ($ids | length) == 1 then $ids[0] else error("issuer") end] as $ids
+    | if (($ids | length) == ($contexts | length)
+          and ($ids | length) > 0 and ($ids | unique | length) == 1)
+      then $ids[0] else error("common issuer") end')"; then
+    echo "error: required-check evidence did not yield one common numeric App ID." >&2
+    return 1
+  fi
+  PAYLOAD="$(printf '%s' "$PAYLOAD" | jq --argjson app_id "$app_id" '
+    (.rules[] | select(.type == "pull_request").parameters)
+      |= (.dismiss_stale_reviews_on_push = true
+          | .require_code_owner_review = true
+          | .require_last_push_approval = true
+          | .required_review_thread_resolution = true)
+    | (.rules[] | select(.type == "required_status_checks").parameters)
+      |= (.strict_required_status_checks_policy = true
+          | .required_status_checks |= map(. + {integration_id: $app_id}))')"
+}
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  discover_team_payload || exit 1
+  echo "dry-run: GET-only team discovery completed; no variable or ruleset write made." >&2
+  printf '%s\n' "$PAYLOAD"
+  exit 0
+fi
+
 # Idempotency: a ruleset with the target name already existing means a prior
 # run (or a human) owns it — skip instead of creating a same-name duplicate.
 # The list call must succeed before we may create anything: proceeding on a
@@ -178,6 +236,11 @@ fi
 EXISTING_ID="$(printf '%s' "$RULESETS_JSON" \
   | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].id // empty')"
 if [[ -n "$EXISTING_ID" ]]; then
+  if [[ -n "$PROFILE" ]]; then
+    echo "error: ruleset '$NAME' already exists on $REPO; reconciliation is required." >&2
+    echo "       Explicit profiles support fresh creation only." >&2
+    exit 1
+  fi
   EXISTING_ENFORCEMENT="$(printf '%s' "$RULESETS_JSON" \
     | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].enforcement // "unknown"')"
   if [[ "$EXISTING_ENFORCEMENT" == "$ENFORCEMENT" ]]; then
@@ -200,11 +263,62 @@ if [[ -n "$EXISTING_ID" ]]; then
   exit 0
 fi
 
+if [[ "$PROFILE" == "team" ]]; then
+  discover_team_payload || exit 1
+fi
+
+if [[ -n "$PROFILE" ]]; then
+  VARIABLE_PATH="repos/$REPO/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE"
+  VARIABLE_PRESENT="false"
+  VARIABLE_RESULT=""
+  if VARIABLE_RESULT="$(gh api "$VARIABLE_PATH" 2>&1)"; then
+    if ! printf '%s' "$VARIABLE_RESULT" \
+      | jq -e '.name == "SCAFFOLD_GOVERNANCE_PROFILE"' >/dev/null; then
+      echo "error: governance profile variable response was malformed." >&2
+      exit 1
+    fi
+    VARIABLE_PRESENT="true"
+  elif printf '%s' "$VARIABLE_RESULT" | grep -q 'HTTP 404'; then
+    if ! VARIABLES_JSON="$(gh api "repos/$REPO/actions/variables?per_page=100")"; then
+      echo "error: variable endpoint unavailable; governance profile was not persisted." >&2
+      exit 1
+    fi
+    if ! printf '%s' "$VARIABLES_JSON" | jq -e \
+      '(.variables // []) | all(.name != "SCAFFOLD_GOVERNANCE_PROFILE")' >/dev/null; then
+      echo "error: variable absence could not be proven." >&2
+      exit 1
+    fi
+  else
+    echo "error: governance profile variable could not be read." >&2
+    exit 1
+  fi
+
+  VARIABLE_METHOD="POST"
+  VARIABLE_TARGET="repos/$REPO/actions/variables"
+  if [[ "$VARIABLE_PRESENT" == "true" ]]; then
+    VARIABLE_METHOD="PATCH"
+    VARIABLE_TARGET="$VARIABLE_PATH"
+  fi
+  if ! gh api --method "$VARIABLE_METHOD" "$VARIABLE_TARGET" \
+    -f name=SCAFFOLD_GOVERNANCE_PROFILE -f value="$PROFILE" >/dev/null; then
+    echo "error: governance profile variable persistence failed; ruleset was not created." >&2
+    exit 1
+  fi
+fi
+
 if [[ "$ENFORCEMENT" == "active" ]]; then
   echo "warning: enforcement 'active' starts blocking merges on $REPO immediately." >&2
 fi
 
-RESPONSE="$(printf '%s' "$PAYLOAD" | gh api --method POST "repos/$REPO/rulesets" --input -)"
+if [[ -n "$PROFILE" ]]; then
+  if ! RESPONSE="$(printf '%s' "$PAYLOAD" \
+    | gh api --method POST "repos/$REPO/rulesets" --input -)"; then
+    echo "error: governance profile persisted, but ruleset creation failed." >&2
+    exit 1
+  fi
+else
+  RESPONSE="$(printf '%s' "$PAYLOAD" | gh api --method POST "repos/$REPO/rulesets" --input -)"
+fi
 RULESET_ID="$(printf '%s' "$RESPONSE" | jq -r '.id')"
 
 echo "Created ruleset '$NAME' (id: $RULESET_ID, enforcement: $ENFORCEMENT) on $REPO."

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -15,9 +15,8 @@ SCRIPT="$HERE/../setup-ruleset.sh"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# Recording stub: every invocation lands in $GH_CALLS (one line of argv per
-# call); list responses come from $GH_FIXTURES/rulesets.json (absent file
-# models a failed list); a POST body is captured to $GH_FIXTURES/posted.json.
+# Recording stub: every invocation lands in $GH_CALLS. Missing fixtures fail;
+# a `.missing` marker returns a proven 404. Write-failure markers are explicit.
 export GH_FIXTURES="$WORK/fixtures"
 export GH_CALLS="$WORK/gh-calls.log"
 mkdir -p "$GH_FIXTURES" "$WORK/bin"
@@ -30,9 +29,33 @@ case "$*" in
   "api repos/"*"/rulesets")
     [ -f "$GH_FIXTURES/rulesets.json" ] || exit 1
     cat "$GH_FIXTURES/rulesets.json" ;;
+  "api repos/"*"/commits/"*"/check-runs?filter=latest&per_page=100 --paginate --slurp"|"api --paginate --slurp repos/"*"/commits/"*"/check-runs?filter=latest&per_page=100")
+    [ ! -f "$GH_FIXTURES/check-runs.forbidden" ] \
+      || { echo "gh: Forbidden (HTTP 403)" >&2; exit 1; }
+    [ -f "$GH_FIXTURES/check-runs.json" ] || exit 1
+    cat "$GH_FIXTURES/check-runs.json" ;;
+  "api repos/"*"/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE")
+    if [ -f "$GH_FIXTURES/variable.json" ]; then cat "$GH_FIXTURES/variable.json"
+    elif [ -f "$GH_FIXTURES/variable.missing" ]; then
+      echo "gh: Not Found (HTTP 404)" >&2; exit 1
+    else echo "gh: Forbidden (HTTP 403)" >&2; exit 1; fi ;;
+  "api repos/"*"/actions/variables?per_page=100")
+    [ -f "$GH_FIXTURES/variables.json" ] || exit 1
+    cat "$GH_FIXTURES/variables.json" ;;
+  "api repos/"*)
+    [ -f "$GH_FIXTURES/repo.json" ] || exit 1
+    cat "$GH_FIXTURES/repo.json" ;;
   "api --method PUT repos/"*"/rulesets/"*) echo '{}' ;;
+  "api --method POST repos/"*"/actions/variables -f name=SCAFFOLD_GOVERNANCE_PROFILE -f value="*)
+    [ ! -f "$GH_FIXTURES/variable-write.fail" ] || exit 1
+    printf '%s\n' "$*" > "$GH_FIXTURES/variable-write.txt" ;;
+  "api --method PATCH repos/"*"/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE -f name=SCAFFOLD_GOVERNANCE_PROFILE -f value="*)
+    [ ! -f "$GH_FIXTURES/variable-write.fail" ] || exit 1
+    printf '%s\n' "$*" > "$GH_FIXTURES/variable-write.txt" ;;
   "api --method POST repos/"*"/rulesets --input -")
-    cat > "$GH_FIXTURES/posted.json"; echo '{"id": 999}' ;;
+    cat > "$GH_FIXTURES/posted.json"
+    [ ! -f "$GH_FIXTURES/ruleset-write.fail" ] || exit 1
+    echo '{"id": 999}' ;;
   *) echo "gh stub: unsupported invocation: $*" >&2; exit 64 ;;
 esac
 STUB
@@ -40,12 +63,41 @@ chmod +x "$WORK/bin/gh"
 PATH="$WORK/bin:$PATH"
 export PATH
 
-reset_calls() { : > "$GH_CALLS"; }
+reset_calls() {
+  : > "$GH_CALLS"
+  rm -f "$GH_FIXTURES/variable.json" \
+    "$GH_FIXTURES/variable.missing" "$GH_FIXTURES/variables.json" \
+    "$GH_FIXTURES/variable-write.fail" "$GH_FIXTURES/variable-write.txt" \
+    "$GH_FIXTURES/ruleset-write.fail" "$GH_FIXTURES/repo.json" \
+    "$GH_FIXTURES/check-runs.json" "$GH_FIXTURES/check-runs.forbidden" \
+    "$GH_FIXTURES/posted.json"
+}
+
+valid_team() {
+  echo '{"default_branch":"main"}' > "$GH_FIXTURES/repo.json"
+  cat > "$GH_FIXTURES/check-runs.json" <<'JSON'
+[{"check_runs":[
+  {"name":"quality","app":{"id":77}},{"name":"task-ritual","app":{"id":77}}
+]},{"check_runs":[
+  {"name":"scaffold-self-check","app":{"id":77}},
+  {"name":"copilot-surface","app":{"id":77}}
+]}]
+JSON
+}
+
+assert_no_writes() {
+  if ! grep -Eq -- '--method (POST|PUT|PATCH|DELETE)' "$GH_CALLS"; then
+    t_ok "$1"
+  else
+    t_fail "$1"; sed 's/^/    # /' "$GH_CALLS"
+  fi
+}
 
 run_script() { bash "$SCRIPT" "$@" < /dev/null; }
 
 # --- usage ----------------------------------------------------------------
 
+expect_rc 0 "recording gh authenticates by default" gh api user --jq .login
 expect_rc_grep 0 'Usage: setup-ruleset\.sh' "--help prints usage" \
   run_script --help
 expect_rc_grep 2 'unknown argument' "unknown flag is a usage error" \
@@ -53,6 +105,8 @@ expect_rc_grep 2 'unknown argument' "unknown flag is a usage error" \
 expect_rc_grep 2 "must be 'active' or 'disabled'" \
   "invalid --enforcement is a usage error" \
   run_script --enforcement sometimes
+expect_rc_grep 2 "profile.*solo.*team" "invalid profile is a usage error" \
+  run_script --profile enterprise
 
 # --- dry-run: valid payload, zero gh calls ---------------------------------
 
@@ -76,6 +130,32 @@ else
   sed 's/^/    # /' "$GH_CALLS"
 fi
 
+reset_calls
+SOLO="$(run_script --profile solo --dry-run 2>/dev/null || true)"
+if printf '%s' "$SOLO" | jq -e '
+  all(.rules[] | select(.type == "pull_request").parameters;
+    (.dismiss_stale_reviews_on_push or .require_last_push_approval
+     or .require_code_owner_review or .required_review_thread_resolution) | not)
+  and all(.rules[] | select(.type == "required_status_checks").parameters;
+    .strict_required_status_checks_policy | not)
+' >/dev/null; then t_ok "solo dry-run is the current solo payload"
+else t_fail "solo dry-run is the current solo payload"; fi
+assert_no_writes "solo dry-run makes no mutation"
+
+reset_calls; valid_team
+TEAM="$(run_script -R acme/widget --profile team --dry-run 2>/dev/null || true)"
+if printf '%s' "$TEAM" | jq -e '
+  ([.rules[] | select(.type == "required_status_checks")
+    | .parameters.required_status_checks[].integration_id] == [77,77,77,77])
+  and all(.rules[] | select(.type == "pull_request").parameters;
+    .dismiss_stale_reviews_on_push and .require_last_push_approval
+    and .require_code_owner_review and .required_review_thread_resolution)
+  and all(.rules[] | select(.type == "required_status_checks").parameters;
+    .strict_required_status_checks_policy)
+' >/dev/null; then t_ok "team dry-run is source-bound and enables team controls"
+else t_fail "team dry-run is source-bound and enables team controls"; fi
+assert_no_writes "team dry-run uses GET-only discovery"
+
 # --- fresh create -----------------------------------------------------------
 
 reset_calls
@@ -92,6 +172,78 @@ if jq -e '
 else
   t_fail "POSTed body carries requested enforcement and the bypass actor"
 fi
+
+# --- explicit profiles: discovery, persistence, and ordering ----------------
+
+reset_calls
+echo '[{"id":42,"name":"scaffold-branch-protection","enforcement":"disabled"}]' > "$GH_FIXTURES/rulesets.json"
+expect_rc_grep 1 'reconciliation.*required' "explicit profile rejects same-name ruleset" \
+  run_script -R acme/widget --profile solo
+assert_no_writes "same-name explicit profile performs no write"
+
+reset_calls; echo '[]' > "$GH_FIXTURES/rulesets.json"; touch "$GH_FIXTURES/variable.missing"
+echo '{"variables":[]}' > "$GH_FIXTURES/variables.json"
+expect_rc_grep 0 "Created ruleset" "absent variable is created before solo ruleset" \
+  run_script -R acme/widget --profile solo
+if sed -n '1p;2p;3p;4p;5p' "$GH_CALLS" | grep -q \
+  $'api user --jq .login\napi repos/acme/widget/rulesets\napi repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE\napi repos/acme/widget/actions/variables?per_page=100\napi --method POST repos/acme/widget/actions/variables'; then
+  t_ok "solo reads precede variable creation and ruleset POST"
+else t_fail "solo reads precede variable creation and ruleset POST"; sed 's/^/    # /' "$GH_CALLS"; fi
+
+reset_calls; valid_team
+echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' > "$GH_FIXTURES/variable.json"
+expect_rc_grep 0 "Created ruleset" "existing variable is updated before team ruleset" \
+  run_script -R acme/widget --profile team
+if grep -q -- 'value=team' "$GH_FIXTURES/variable-write.txt" \
+   && [ "$(grep -n -- '--method PATCH\|--method POST repos/.*/rulesets' "$GH_CALLS" | cut -d: -f1 | paste -sd, -)" = "6,7" ]; then
+  t_ok "team completes auth/list/discovery/variable reads before ordered writes"
+else t_fail "team completes auth/list/discovery/variable reads before ordered writes"; sed 's/^/    # /' "$GH_CALLS"; fi
+
+team_failure() {
+  local name="$1" runs="$2"
+  reset_calls; echo '{"default_branch":"main"}' > "$GH_FIXTURES/repo.json"
+  printf '%s\n' "$runs" > "$GH_FIXTURES/check-runs.json"
+  expect_rc_grep 1 'check.*evidence|App ID|discover' "$name" \
+    run_script -R acme/widget --profile team --dry-run
+  assert_no_writes "$name performs no write"
+}
+team_failure "missing context fails closed" \
+  '[{"check_runs":[{"name":"quality","app":{"id":77}}]}]'
+team_failure "ambiguous issuer fails closed" \
+  '[{"check_runs":[{"name":"quality","app":{"id":77}},{"name":"quality","app":{"id":88}},{"name":"task-ritual","app":{"id":77}},{"name":"scaffold-self-check","app":{"id":77}},{"name":"copilot-surface","app":{"id":77}}]}]'
+team_failure "mixed issuers fail closed" \
+  '[{"check_runs":[{"name":"quality","app":{"id":77}},{"name":"task-ritual","app":{"id":77}},{"name":"scaffold-self-check","app":{"id":88}},{"name":"copilot-surface","app":{"id":88}}]}]'
+team_failure "malformed issuer fails closed" \
+  '[{"check_runs":[{"name":"quality","app":{"id":"77"}},{"name":"task-ritual","app":{"id":77}},{"name":"scaffold-self-check","app":{"id":77}},{"name":"copilot-surface","app":{"id":77}}]}]'
+
+reset_calls; echo '{"default_branch":"main"}' > "$GH_FIXTURES/repo.json"
+expect_rc_grep 1 'check.*runs|discover' "check-run API failure fails closed" \
+  run_script -R acme/widget --profile team --dry-run
+assert_no_writes "check-run API failure performs no write"
+reset_calls; valid_team; touch "$GH_FIXTURES/check-runs.forbidden"
+expect_rc_grep 1 'check.*runs|discover' "check-run authorization failure fails closed" \
+  run_script -R acme/widget --profile team --dry-run
+assert_no_writes "check-run authorization failure performs no write"
+
+for mode in read create update; do
+  reset_calls
+  case "$mode" in
+    read) : ;;
+    create) touch "$GH_FIXTURES/variable.missing" "$GH_FIXTURES/variable-write.fail"; echo '{"variables":[]}' > "$GH_FIXTURES/variables.json" ;;
+    update) echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' > "$GH_FIXTURES/variable.json"; touch "$GH_FIXTURES/variable-write.fail" ;;
+  esac
+  expect_rc_grep 1 'variable' "variable $mode failure stops ruleset creation" \
+    run_script -R acme/widget --profile solo
+  [ ! -f "$GH_FIXTURES/posted.json" ] && t_ok "variable $mode failure causes zero ruleset POSTs" \
+    || t_fail "variable $mode failure causes zero ruleset POSTs"
+done
+
+reset_calls; echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' > "$GH_FIXTURES/variable.json"
+touch "$GH_FIXTURES/ruleset-write.fail"
+expect_rc_grep 1 'ruleset.*creat' "ruleset-create failure is distinct" \
+  run_script -R acme/widget --profile solo
+if ! grep -q -- '--method DELETE' "$GH_CALLS"; then t_ok "no path creates or deletes probe rulesets"
+else t_fail "no path creates or deletes probe rulesets"; fi
 
 # --- exists, same enforcement: skip, no writes ------------------------------
 

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -241,8 +241,11 @@ for mode in read create update; do
   esac
   expect_rc_grep 1 'variable' "variable $mode failure stops ruleset creation" \
     run_script -R acme/widget --profile solo
-  [ ! -f "$GH_FIXTURES/posted.json" ] && t_ok "variable $mode failure causes zero ruleset POSTs" \
-    || t_fail "variable $mode failure causes zero ruleset POSTs"
+  if [ ! -f "$GH_FIXTURES/posted.json" ]; then
+    t_ok "variable $mode failure causes zero ruleset POSTs"
+  else
+    t_fail "variable $mode failure causes zero ruleset POSTs"
+  fi
 done
 
 reset_calls; echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' > "$GH_FIXTURES/variable.json"

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -77,7 +77,8 @@ valid_team() {
   echo '{"default_branch":"main"}' > "$GH_FIXTURES/repo.json"
   cat > "$GH_FIXTURES/check-runs.json" <<'JSON'
 [{"check_runs":[
-  {"name":"quality","app":{"id":77}},{"name":"task-ritual","app":{"id":77}}
+  {"name":"quality","app":{"id":77}},{"name":"quality","app":{"id":77}},
+  {"name":"task-ritual","app":{"id":77}}
 ]},{"check_runs":[
   {"name":"scaffold-self-check","app":{"id":77}},
   {"name":"copilot-surface","app":{"id":77}}
@@ -140,7 +141,8 @@ if printf '%s' "$SOLO" | jq -e '
     .strict_required_status_checks_policy | not)
 ' >/dev/null; then t_ok "solo dry-run is the current solo payload"
 else t_fail "solo dry-run is the current solo payload"; fi
-assert_no_writes "solo dry-run makes no mutation"
+if [ ! -s "$GH_CALLS" ]; then t_ok "solo dry-run requires no remote evidence"
+else t_fail "solo dry-run requires no remote evidence"; sed 's/^/    # /' "$GH_CALLS"; fi
 
 reset_calls; valid_team
 TEAM="$(run_script -R acme/widget --profile team --dry-run 2>/dev/null || true)"
@@ -180,6 +182,9 @@ echo '[{"id":42,"name":"scaffold-branch-protection","enforcement":"disabled"}]' 
 expect_rc_grep 1 'reconciliation.*required' "explicit profile rejects same-name ruleset" \
   run_script -R acme/widget --profile solo
 assert_no_writes "same-name explicit profile performs no write"
+if ! grep -q 'actions/variables' "$GH_CALLS"; then
+  t_ok "same-name rejection precedes variable reads"
+else t_fail "same-name rejection precedes variable reads"; fi
 
 reset_calls; echo '[]' > "$GH_FIXTURES/rulesets.json"; touch "$GH_FIXTURES/variable.missing"
 echo '{"variables":[]}' > "$GH_FIXTURES/variables.json"
@@ -187,7 +192,9 @@ expect_rc_grep 0 "Created ruleset" "absent variable is created before solo rules
   run_script -R acme/widget --profile solo
 if sed -n '1p;2p;3p;4p;5p' "$GH_CALLS" | grep -q \
   $'api user --jq .login\napi repos/acme/widget/rulesets\napi repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE\napi repos/acme/widget/actions/variables?per_page=100\napi --method POST repos/acme/widget/actions/variables'; then
-  t_ok "solo reads precede variable creation and ruleset POST"
+  if [ "$(grep -n -- '--method POST' "$GH_CALLS" | cut -d: -f1 | paste -sd, -)" = "5,6" ]; then
+    t_ok "solo reads precede ordered variable and ruleset writes"
+  else t_fail "solo reads precede ordered variable and ruleset writes"; fi
 else t_fail "solo reads precede variable creation and ruleset POST"; sed 's/^/    # /' "$GH_CALLS"; fi
 
 reset_calls; valid_team
@@ -226,7 +233,7 @@ expect_rc_grep 1 'check.*runs|discover' "check-run authorization failure fails c
 assert_no_writes "check-run authorization failure performs no write"
 
 for mode in read create update; do
-  reset_calls
+  reset_calls; echo '[]' > "$GH_FIXTURES/rulesets.json"
   case "$mode" in
     read) : ;;
     create) touch "$GH_FIXTURES/variable.missing" "$GH_FIXTURES/variable-write.fail"; echo '{"variables":[]}' > "$GH_FIXTURES/variables.json" ;;


### PR DESCRIPTION
Closes #95

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/95#issuecomment-5311390749

## Summary

Add explicit `solo` and `team` fresh-create profiles while preserving the omitted-profile actuator path. Team mode discovers one common GitHub App issuer from paginated latest default-branch check runs, source-binds every requested context, and persists declared intent before creating the ruleset. Fixed recording-`gh` fixtures enforce fail-closed discovery, persistence, dry-run, and write-order boundaries.

## Evidence

| Criterion | Evidence (command / link) | Result |
|---|---|---|
| Tests-first fixture wall committed and expected-red before production | Commits `0fece6c` and `e870677`; `bash .github/scripts/tests/run-tests.sh setup-ruleset` before implementation: 47 cases with 18 new-contract failures while all legacy assertions passed | pass |
| Accept `--profile solo\|team`; invalid values fail; omitted profile remains compatible | Focused wall: 47/47; legacy dry-run/create/skip/promotion/demotion/list-failure assertions all pass | pass |
| Bare/solo/team dry-run boundaries | Focused wall verifies zero calls for bare/solo and GET-only team discovery; live team dry-run emitted the candidate payload and no writes | pass |
| Explicit-profile same-name ruleset requires reconciliation before variable access/writes | Focused wall: same-name rejection, no writes, and no variable reads | pass |
| Paginated default-branch discovery fails closed for missing/ambiguous/mixed/malformed/API/auth evidence | Recording fixtures cover two pages plus every stated negative case; focused wall 47/47 | pass |
| Team payload enables five controls and source-binds every requested context without a constant | Live read-only payload probe jq expression returned `true`; fixture issuer is derived and production contains no App-ID constant | pass |
| Explicit solo is current payload; stronger controls remain opt-in | Solo dry-run fixture validates all five controls remain disabled and requires no remote evidence | pass |
| All reads precede variable create/update and ruleset POST | Recording call-order assertions pin solo writes at calls 5/6 and team writes at 6/7 | pass |
| Variable endpoint/read/create/update failures stop before ruleset writes; ruleset failure is distinct | Focused negative fixtures all pass and assert zero later POSTs | pass |
| No DELETE/probe/dry-run/failure-path mutation | Recording fixture rejects forbidden write forms and confirms no DELETE | pass |
| Bash 3.2/existing dependencies/size wall | `shellcheck -S style` passed; full 23-file suite and all listed guards passed; owned-path diff is 290 changed lines (≤400) | pass |

## Deviations

None.

## Follow-ups

None.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and is linked above.
- [x] Diff stays inside the issue's **File ownership** paths.
- [x] Every command in the issue's **Verification** section was run; evidence is mapped above.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [ ] Record-before-report comment posted on the Task issue (supervisor-owned; worker is prohibited from posting Task comments).
- [x] All persistent artifacts in this PR are English-only.

Worker verification and both required Rubber Duck gates are complete. This PR remains draft pending supervisor verification and the fresh custom reviewer audit.