### PR TITLE
Add opt-in source-bound ruleset profiles

### DIFF
--- a/.github/scripts/setup-ruleset.sh
+++ b/.github/scripts/setup-ruleset.sh
@@ -55,6 +55,9 @@ Options:
                            the ruleset never blocks merges until a human
                            reviews it and enables it.
   --name <name>            Ruleset name. Default: scaffold-branch-protection.
+  --profile <solo|team>    Persist explicit governance intent and create a
+                           fresh profile ruleset. Existing rulesets require
+                           separate reconciliation.
   --dry-run                Print the request JSON body to stdout and exit
                            without making any API call.
   -h, --help               Show this help and exit.
@@ -75,6 +78,7 @@ CHECKS="quality,task-ritual,scaffold-self-check,copilot-surface"
 ENFORCEMENT="disabled"
 NAME="scaffold-branch-protection"
 DRY_RUN="false"
+PROFILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -93,6 +97,12 @@ while [[ $# -gt 0 ]]; do
     --name)
       [[ -n "${2:-}" ]] || { echo "error: --name requires a value" >&2; exit 2; }
       NAME="$2"; shift 2 ;;
+    --profile)
+      case "${2:-}" in
+        solo|team) PROFILE="$2" ;;
+        *) echo "error: --profile must be 'solo' or 'team'" >&2; exit 2 ;;
+      esac
+      shift 2 ;;
     --dry-run)
       DRY_RUN="true"; shift ;;
     -h|--help)
@@ -149,6 +159,133 @@ PAYLOAD="$(jq -n \
       }
     ]
   }')"
+
+if [[ -n "$PROFILE" ]]; then
+  if [[ "$PROFILE" == "solo" && "$DRY_RUN" == "true" ]]; then
+    echo "dry-run: explicit solo candidate; no API call made." >&2
+    printf '%s\n' "$PAYLOAD"
+    exit 0
+  fi
+
+  command -v gh >/dev/null 2>&1 \
+    || { echo "error: gh CLI not found on PATH" >&2; exit 1; }
+  if [[ -z "$REPO" ]]; then
+    REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+  fi
+  [[ "$REPO" == */* ]] \
+    || { echo "error: repository must be owner/repo, got: $REPO" >&2; exit 2; }
+
+  if [[ "$DRY_RUN" != "true" ]]; then
+    gh api user --jq .login >/dev/null 2>&1 \
+      || { echo "error: gh is not authenticated" >&2; exit 1; }
+    if ! RULESETS_JSON="$(gh api "repos/$REPO/rulesets")"; then
+      echo "error: could not list rulesets for $REPO; aborting before writes." >&2
+      exit 1
+    fi
+    EXISTING_ID="$(printf '%s' "$RULESETS_JSON" \
+      | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].id // empty')"
+    if [[ -n "$EXISTING_ID" ]]; then
+      echo "error: ruleset '$NAME' already exists; explicit-profile reconciliation required." >&2
+      exit 1
+    fi
+  fi
+
+  if [[ "$PROFILE" == "team" ]]; then
+    if ! REPO_JSON="$(gh api "repos/$REPO")"; then
+      echo "error: repository metadata unavailable for team profile." >&2
+      exit 1
+    fi
+    DEFAULT_BRANCH="$(printf '%s' "$REPO_JSON" | jq -r '.default_branch // empty')"
+    if [[ -z "$DEFAULT_BRANCH" ]]; then
+      echo "error: repository metadata has no default branch." >&2
+      exit 1
+    fi
+    if ! CHECK_RUNS="$(gh api \
+      "repos/$REPO/commits/$DEFAULT_BRANCH/check-runs?filter=latest&per_page=100" \
+      --paginate)"; then
+      echo "error: check-run evidence unavailable for team profile." >&2
+      exit 1
+    fi
+
+    CONTEXTS="$(jq -nr --arg checks "$CHECKS" \
+      '$checks | split(",") | map(gsub("^\\s+|\\s+$"; ""))
+       | map(select(length > 0)) | .[]')"
+    [[ -n "$CONTEXTS" ]] \
+      || { echo "error: team profile requires at least one check context." >&2; exit 1; }
+    COMMON_ID=""
+    while IFS= read -r context; do
+      IDS="$(printf '%s' "$CHECK_RUNS" | jq -s -c --arg context "$context" \
+        '[.[].check_runs[] | select(.name == $context) | .app.id]')"
+      if ! printf '%s' "$IDS" | jq -e '
+        length > 0
+        and all(.[]; type == "number" and . >= 0 and floor == .)
+        and (unique | length == 1)
+      ' >/dev/null; then
+        echo "error: invalid or ambiguous issuer evidence for context '$context'." >&2
+        exit 1
+      fi
+      CONTEXT_ID="$(printf '%s' "$IDS" | jq -r 'unique[0]')"
+      if [[ -n "$COMMON_ID" && "$COMMON_ID" != "$CONTEXT_ID" ]]; then
+        echo "error: requested check contexts have different issuers." >&2
+        exit 1
+      fi
+      COMMON_ID="$CONTEXT_ID"
+    done <<EOF
+$CONTEXTS
+EOF
+
+    PAYLOAD="$(printf '%s' "$PAYLOAD" | jq --argjson app "$COMMON_ID" '
+      (.rules[] | select(.type == "pull_request").parameters) |=
+        (.dismiss_stale_reviews_on_push = true
+         | .require_last_push_approval = true
+         | .require_code_owner_review = true
+         | .required_review_thread_resolution = true)
+      | (.rules[] | select(.type == "required_status_checks").parameters) |=
+        (.strict_required_status_checks_policy = true
+         | .required_status_checks |= map(. + {integration_id: $app}))
+    ')"
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "dry-run: explicit team candidate from GET-only evidence; no mutation made." >&2
+    printf '%s\n' "$PAYLOAD"
+    exit 0
+  fi
+
+  VARIABLE_PATH="repos/$REPO/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE"
+  VARIABLE_EXISTS="true"
+  VARIABLE_RESULT=""
+  if ! VARIABLE_RESULT="$(gh api "$VARIABLE_PATH" 2>&1)"; then
+    case "$VARIABLE_RESULT" in
+      *"HTTP 404"*) VARIABLE_EXISTS="false" ;;
+      *) echo "error: governance profile variable is unreadable: $VARIABLE_RESULT" >&2; exit 1 ;;
+    esac
+  fi
+  VARIABLE_BODY="$(jq -n --arg value "$PROFILE" \
+    '{name: "SCAFFOLD_GOVERNANCE_PROFILE", value: $value}')"
+  if [[ "$VARIABLE_EXISTS" == "true" ]]; then
+    if ! printf '%s' "$VARIABLE_BODY" | gh api --method PATCH "$VARIABLE_PATH" --input - >/dev/null; then
+      echo "error: could not update governance profile variable." >&2
+      exit 1
+    fi
+  else
+    if ! printf '%s' "$VARIABLE_BODY" \
+      | gh api --method POST "repos/$REPO/actions/variables" --input - >/dev/null; then
+      echo "error: could not create governance profile variable." >&2
+      exit 1
+    fi
+  fi
+
+  if ! RESPONSE="$(printf '%s' "$PAYLOAD" \
+    | gh api --method POST "repos/$REPO/rulesets" --input -)"; then
+    echo "error: governance intent persisted, but ruleset creation failed." >&2
+    exit 1
+  fi
+  RULESET_ID="$(printf '%s' "$RESPONSE" | jq -r '.id')"
+  echo "Created ruleset '$NAME' (id: $RULESET_ID, enforcement: $ENFORCEMENT) on $REPO."
+  echo "Recorded governance profile: $PROFILE."
+  exit 0
+fi
 
 if [[ "$DRY_RUN" == "true" ]]; then
   # stdout carries only the JSON body (pipeable to jq); notes go to stderr.

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -3,7 +3,8 @@
 # errors, the write-free dry-run, fresh creation (payload carries the
 # admin PR-only bypass), the exists-same-enforcement skip, the
 # exists-different-enforcement PUT promotion (#187), and the fail-loud
-# list. Sandboxed: a recording gh PATH stub — no network, no auth.
+# list, plus opt-in solo/team profiles and fail-closed source discovery.
+# Sandboxed: a recording gh PATH stub — no network, no auth.
 
 set -euo pipefail
 
@@ -20,19 +21,41 @@ trap 'rm -rf "$WORK"' EXIT
 # models a failed list); a POST body is captured to $GH_FIXTURES/posted.json.
 export GH_FIXTURES="$WORK/fixtures"
 export GH_CALLS="$WORK/gh-calls.log"
+export GH_ALL_CALLS="$WORK/gh-all-calls.log"
 mkdir -p "$GH_FIXTURES" "$WORK/bin"
 cat > "$WORK/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$GH_CALLS"
+printf '%s\n' "$*" >> "$GH_ALL_CALLS"
+[ "${GH_FAIL_EXACT:-}" != "$*" ] \
+  || { echo "${GH_FAIL_MESSAGE:-gh: HTTP 500 (simulated)}" >&2; exit 1; }
+for frag in ${GH_FAIL:-}; do
+  case "$*" in
+    *"$frag"*) echo "${GH_FAIL_MESSAGE:-gh: HTTP 500 (simulated)}" >&2; exit 1 ;;
+  esac
+done
 case "$*" in
   "api user --jq .login") echo someone ;;
+  "api repos/"*"/commits/"*"/check-runs?filter=latest&per_page=100 --paginate"|"api --paginate repos/"*"/commits/"*"/check-runs?filter=latest&per_page=100")
+    cat "$GH_FIXTURES/checkruns.json" ;;
+  "api repos/"*"/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE")
+    case "${GH_VARIABLE:-present}" in
+      missing) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+      *) cat "$GH_FIXTURES/variable.json" ;;
+    esac ;;
+  "api --method POST repos/"*"/actions/variables --input -")
+    cat > "$GH_FIXTURES/variable-written.json"; echo '{}' ;;
+  "api --method PATCH repos/"*"/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE --input -")
+    cat > "$GH_FIXTURES/variable-written.json"; echo '{}' ;;
   "api repos/"*"/rulesets")
     [ -f "$GH_FIXTURES/rulesets.json" ] || exit 1
     cat "$GH_FIXTURES/rulesets.json" ;;
   "api --method PUT repos/"*"/rulesets/"*) echo '{}' ;;
   "api --method POST repos/"*"/rulesets --input -")
     cat > "$GH_FIXTURES/posted.json"; echo '{"id": 999}' ;;
+  "api repos/"*)
+    cat "$GH_FIXTURES/repo.json" ;;
   *) echo "gh stub: unsupported invocation: $*" >&2; exit 64 ;;
 esac
 STUB
@@ -44,6 +67,42 @@ reset_calls() { : > "$GH_CALLS"; }
 
 run_script() { bash "$SCRIPT" "$@" < /dev/null; }
 
+no_profile_writes() {
+  ! grep -Eq -- '--method (POST|PUT|PATCH).*(actions/variables|rulesets)' "$GH_CALLS"
+}
+
+profile_fixtures() {
+  reset_calls
+  unset GH_FAIL GH_FAIL_EXACT GH_FAIL_MESSAGE
+  export GH_VARIABLE=missing
+  rm -f "$GH_FIXTURES/variable.json" "$GH_FIXTURES/variable-written.json" \
+    "$GH_FIXTURES/posted.json"
+  echo '[]' > "$GH_FIXTURES/rulesets.json"
+  echo '{"default_branch":"trunk"}' > "$GH_FIXTURES/repo.json"
+  cat > "$GH_FIXTURES/checkruns.json" <<'JSON'
+{"check_runs":[
+  {"name":"quality","app":{"id":15368}},
+  {"name":"task-ritual","app":{"id":15368}},
+  {"name":"scaffold-self-check","app":{"id":15368}},
+  {"name":"copilot-surface","app":{"id":15368}}
+]}
+JSON
+}
+
+team_fails_closed() {
+  local name="$1" pattern="$2" rc=0 out
+  out="$(run_script -R acme/widget --profile team 2>&1)" || rc=$?
+  if [ "$rc" -eq 1 ] \
+     && printf '%s\n' "$out" | grep -Eqi "$pattern" \
+     && no_profile_writes; then
+    t_ok "$name"
+  else
+    t_fail "$name (rc=$rc; expected failure before writes)"
+    printf '%s\n' "$out" | sed 's/^/    # /'
+    sed 's/^/    # call: /' "$GH_CALLS"
+  fi
+}
+
 # --- usage ----------------------------------------------------------------
 
 expect_rc_grep 0 'Usage: setup-ruleset\.sh' "--help prints usage" \
@@ -53,6 +112,9 @@ expect_rc_grep 2 'unknown argument' "unknown flag is a usage error" \
 expect_rc_grep 2 "must be 'active' or 'disabled'" \
   "invalid --enforcement is a usage error" \
   run_script --enforcement sometimes
+expect_rc_grep 2 "profile.*solo.*team" \
+  "invalid --profile is a usage error" \
+  run_script --profile pirate
 
 # --- dry-run: valid payload, zero gh calls ---------------------------------
 
@@ -140,6 +202,170 @@ if ! grep -Eq -- '--method (PUT|POST)' "$GH_CALLS"; then
 else
   t_fail "failed list performs no write calls"
   sed 's/^/    # /' "$GH_CALLS"
+fi
+
+# --- explicit profiles: dry-run candidates and fresh writes ----------------
+
+profile_fixtures
+rc=0
+SOLO="$(run_script -R acme/widget --profile solo --dry-run 2>/dev/null)" || rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$SOLO" | jq -e '
+     .rules[] | select(.type == "pull_request") | .parameters
+     | (.dismiss_stale_reviews_on_push == false
+        and .require_last_push_approval == false
+        and .require_code_owner_review == false
+        and .required_review_thread_resolution == false)
+   ' >/dev/null && [ ! -s "$GH_CALLS" ]; then
+  t_ok "explicit solo dry-run prints the legacy payload with zero gh calls"
+else
+  t_fail "explicit solo dry-run prints the legacy payload with zero gh calls"
+fi
+
+profile_fixtures
+rc=0
+TEAM="$(run_script -R acme/widget --profile team --dry-run 2>/dev/null)" || rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$TEAM" | jq -e '
+     all(.rules[] | select(.type == "pull_request").parameters;
+       .dismiss_stale_reviews_on_push and .require_last_push_approval
+       and .require_code_owner_review and .required_review_thread_resolution)
+     and all(.rules[] | select(.type == "required_status_checks").parameters;
+       .strict_required_status_checks_policy
+       and all(.required_status_checks[]; .integration_id == 15368))
+   ' >/dev/null \
+   && grep -Eq -- 'commits/trunk/check-runs\?filter=latest&per_page=100.*--paginate' "$GH_CALLS" \
+   && no_profile_writes; then
+  t_ok "team dry-run uses paginated GET evidence and prints a bound candidate"
+else
+  t_fail "team dry-run uses paginated GET evidence and prints a bound candidate"
+fi
+
+profile_fixtures
+expect_rc_grep 0 "Created ruleset 'scaffold-branch-protection'" \
+  "fresh explicit solo persists intent before creating the ruleset" \
+  run_script -R acme/widget --profile solo
+if jq -e '.name == "SCAFFOLD_GOVERNANCE_PROFILE" and .value == "solo"' \
+     "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && [ "$(grep -nE 'actions/variables|--method POST .*rulesets' "$GH_CALLS" \
+             | cut -d: -f2-)" = "$(printf '%s\n' \
+       'api repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' \
+       'api --method POST repos/acme/widget/actions/variables --input -' \
+       'api --method POST repos/acme/widget/rulesets --input -')" ]; then
+  t_ok "explicit solo reads then writes intent before the ruleset POST"
+else
+  t_fail "explicit solo reads then writes intent before the ruleset POST"
+  sed 's/^/    # /' "$GH_CALLS"
+fi
+
+profile_fixtures
+expect_rc 0 "fresh team profile creates from complete common issuer evidence" \
+  run_script -R acme/widget --profile team
+if jq -e '
+     ([.rules[] | select(.type == "required_status_checks")
+       | .parameters.required_status_checks[].integration_id] | unique) == [15368]
+   ' "$GH_FIXTURES/posted.json" >/dev/null \
+   && jq -e '.value == "team"' "$GH_FIXTURES/variable-written.json" >/dev/null; then
+  t_ok "team payload binds every context and persists exact team intent"
+else
+  t_fail "team payload binds every context and persists exact team intent"
+fi
+
+# --- explicit profiles: refusal, discovery, and persistence failures --------
+
+profile_fixtures
+echo '[{"id":42,"name":"scaffold-branch-protection","enforcement":"disabled"}]' \
+  > "$GH_FIXTURES/rulesets.json"
+expect_rc_grep 1 'reconciliation|required.*existing' \
+  "explicit profile refuses an existing same-name ruleset" \
+  run_script -R acme/widget --profile solo
+if grep -q -- 'api repos/acme/widget/rulesets' "$GH_CALLS" \
+   && no_profile_writes; then
+  t_ok "same-name refusal happens before all profile writes"
+else
+  t_fail "same-name refusal happens before all profile writes"
+fi
+
+profile_fixtures
+export GH_FAIL_EXACT='api repos/acme/widget'
+team_fails_closed "repository metadata failure blocks team before writes" \
+  'repository|metadata'
+
+profile_fixtures
+export GH_FAIL='check-runs'
+team_fails_closed "check-run API failure blocks team before writes" 'check.run'
+
+issuer_case=0
+issuer_names=(
+  "missing requested contexts fail closed"
+  "multiple issuers for one context fail closed"
+  "different issuers across contexts fail closed"
+  "numeric plus null evidence fails closed"
+  "numeric plus malformed evidence fails closed"
+)
+for fixture in \
+  '[{"name":"quality","app":{"id":15368}}]' \
+  '[{"name":"quality","app":{"id":15368}},{"name":"quality","app":{"id":42}},{"name":"task-ritual","app":{"id":15368}},{"name":"scaffold-self-check","app":{"id":15368}},{"name":"copilot-surface","app":{"id":15368}}]' \
+  '[{"name":"quality","app":{"id":15368}},{"name":"task-ritual","app":{"id":42}},{"name":"scaffold-self-check","app":{"id":15368}},{"name":"copilot-surface","app":{"id":15368}}]' \
+  '[{"name":"quality","app":{"id":15368}},{"name":"quality","app":{"id":null}},{"name":"task-ritual","app":{"id":15368}},{"name":"scaffold-self-check","app":{"id":15368}},{"name":"copilot-surface","app":{"id":15368}}]' \
+  '[{"name":"quality","app":{"id":15368}},{"name":"quality","app":{"id":"bad"}},{"name":"task-ritual","app":{"id":15368}},{"name":"scaffold-self-check","app":{"id":15368}},{"name":"copilot-surface","app":{"id":15368}}]'
+do
+  profile_fixtures
+  printf '{"check_runs":%s}\n' "$fixture" > "$GH_FIXTURES/checkruns.json"
+  team_fails_closed "${issuer_names[$issuer_case]}" 'issuer|evidence|context'
+  issuer_case=$((issuer_case + 1))
+done
+
+profile_fixtures
+export GH_FAIL='actions/variables/SCAFFOLD_GOVERNANCE_PROFILE'
+team_fails_closed "unreadable variable endpoint blocks ruleset creation" \
+  'variable|Actions'
+
+profile_fixtures
+export GH_FAIL='actions/variables/SCAFFOLD_GOVERNANCE_PROFILE'
+export GH_FAIL_MESSAGE='gh: Actions are disabled (HTTP 409)'
+team_fails_closed "Actions-disabled target blocks ruleset creation" \
+  'variable|Actions'
+
+profile_fixtures
+export GH_FAIL_EXACT='api --method POST repos/acme/widget/actions/variables --input -'
+team_fails_closed "variable create failure blocks ruleset creation" 'variable'
+
+profile_fixtures
+export GH_VARIABLE=present
+echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' \
+  > "$GH_FIXTURES/variable.json"
+expect_rc 0 "existing intent is updated before fresh team creation" \
+  run_script -R acme/widget --profile team
+if grep -q -- '--method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' \
+     "$GH_CALLS" \
+   && ! grep -q -- '--method POST repos/acme/widget/actions/variables' "$GH_CALLS" \
+   && jq -e '.value == "team"' "$GH_FIXTURES/variable-written.json" >/dev/null; then
+  t_ok "existing intent uses PATCH with the exact selected value"
+else
+  t_fail "existing intent uses PATCH with the exact selected value"
+fi
+
+profile_fixtures
+export GH_VARIABLE=present
+echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' \
+  > "$GH_FIXTURES/variable.json"
+export GH_FAIL_EXACT='api --method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE --input -'
+team_fails_closed "variable update failure blocks ruleset creation" 'variable'
+
+profile_fixtures
+export GH_FAIL_EXACT='api --method POST repos/acme/widget/rulesets --input -'
+expect_rc_grep 1 'ruleset.*creat|create.*ruleset' \
+  "ruleset-create failure is reported distinctly" \
+  run_script -R acme/widget --profile team
+if grep -q -- '--method POST repos/acme/widget/actions/variables' "$GH_CALLS"; then
+  t_ok "ruleset-create failure occurs only after intent persistence"
+else
+  t_fail "ruleset-create failure occurs only after intent persistence"
+fi
+
+if grep -Eq -- 'DELETE|probe' "$GH_ALL_CALLS"; then
+  t_fail "fixture wall rejects DELETE and temporary probes"
+else
+  t_ok "fixture wall observes no DELETE or temporary probes"
 fi
 
 t_summary

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -103,6 +103,19 @@ team_fails_closed() {
   fi
 }
 
+variable_write_fails_closed() {
+  local name="$1" endpoint="$2" rc=0 out
+  out="$(run_script -R acme/widget --profile team 2>&1)" || rc=$?
+  if [ "$rc" -eq 1 ] \
+     && printf '%s\n' "$out" | grep -Eqi 'could not (create|update).*variable' \
+     && [ "$(grep -c -- "$endpoint" "$GH_CALLS")" -eq 1 ] \
+     && ! grep -Eq -- '--method (POST|PUT|PATCH|DELETE).*rulesets|probe' "$GH_CALLS"; then
+    t_ok "$name"
+  else
+    t_fail "$name (variable write must fail before any ruleset mutation)"
+  fi
+}
+
 # --- usage ----------------------------------------------------------------
 
 expect_rc_grep 0 'Usage: setup-ruleset\.sh' "--help prints usage" \
@@ -327,7 +340,8 @@ team_fails_closed "Actions-disabled target blocks ruleset creation" \
 
 profile_fixtures
 export GH_FAIL_EXACT='api --method POST repos/acme/widget/actions/variables --input -'
-team_fails_closed "variable create failure blocks ruleset creation" 'variable'
+variable_write_fails_closed "variable create failure blocks ruleset creation" \
+  '--method POST repos/acme/widget/actions/variables'
 
 profile_fixtures
 export GH_VARIABLE=present
@@ -349,7 +363,8 @@ export GH_VARIABLE=present
 echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' \
   > "$GH_FIXTURES/variable.json"
 export GH_FAIL_EXACT='api --method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE --input -'
-team_fails_closed "variable update failure blocks ruleset creation" 'variable'
+variable_write_fails_closed "variable update failure blocks ruleset creation" \
+  '--method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE'
 
 profile_fixtures
 export GH_FAIL_EXACT='api --method POST repos/acme/widget/rulesets --input -'


### PR DESCRIPTION
Closes #99

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/99#issuecomment-5311817740

## Summary

Adds opt-in `--profile solo|team` handling to the explicit ruleset actuator while leaving the no-profile path unchanged. Explicit intent is persisted before fresh ruleset creation; team payloads bind every required context to one common App ID derived from paginated latest check runs on the target repository's default branch. All invalid, incomplete, mixed, unauthorized, unavailable, or failed evidence/persistence paths stop before a ruleset write.

## Tests-first record

- Original tests-only commit/head: `a494b9ead97b94a34948944a738450ff3832ade2`
- Preserved completed expected-red run: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31997677917 (`completed / failure` on the exact tests-only head)
- Expected-red separation: all 14 pre-existing legacy assertions were `ok`; all 24 new profile-contract assertions were `not ok`; the cumulative no-DELETE/no-probe wall was `ok`; summary `39 case(s), 24 failed`.
- Fixture-contract correction: `0951ae6` (test-only), followed by production-only commit `e6e7ad6`.
- First official Rubber Duck gate: PASS after resolving precise failure injection, successful PATCH coverage, default-branch binding, discriminating same-name refusal, per-case failure reasons, and PUT mutation detection.
- Second official Rubber Duck gate: PASS after the complete deterministic wall; no substantive findings.

## Evidence

| Criterion | Evidence (command / link) | Result |
|---|---|---|
| Fixed fixtures committed first with expected-red evidence | Commit `a494b9e`; preserved run `31997677917` on exact head; production appears only in later `e6e7ad6` | pass |
| `--profile solo\|team`; invalid usage; unchanged no-profile path | `bash .github/scripts/tests/run-tests.sh setup-ruleset` -> `39 case(s), 0 failed`; production diff is additive and all legacy assertions pass | pass |
| Bare, solo, and team dry-run boundaries | Focused fixtures prove zero calls for bare/solo and GET-only metadata/check-run discovery for team | pass |
| Explicit-profile same-name refusal before writes | Recording fixture requires rulesets GET, reconciliation-required failure, and zero variable/ruleset writes | pass |
| Paginated default-branch discovery and fail-closed issuer evidence | Fixtures cover nontrivial `trunk`, latest/pagination, missing/multiple/cross-context/numeric+null/numeric+malformed evidence | pass |
| Source-bound team controls with no hard-coded App ID | Live GET-only payload assertion passes for four contexts/one common ID/all five controls; production contains no `15368` | pass |
| Explicit solo equals current solo payload; omission persists nothing | Focused fixtures prove solo payload parity and zero-call solo dry-run; all legacy cases remain green | pass |
| All reads before writes; exact variable persistence before ruleset POST | Recording shim asserts all reads, exact create/update value, variable-before-ruleset ordering | pass |
| Variable endpoint/read/create/update failures and distinct ruleset failure | Focused wall covers unreadable/Actions-disabled/create/update and post-persistence ruleset-create failure | pass |
| Mutation ordering and prohibition wall | Fixtures require zero writes after discovery/read failure, exactly one failed variable write with no later ruleset mutation, and no DELETE/probe/dry-run write | pass |
| Bash 3.2, existing dependencies, <=400 changed lines | Complete issue Verification chain exited 0; full wall reports all 23 guard files passed; shellcheck and all scaffold checks pass; owned-path numstat is 380 | pass |

## Fresh custom reviewer audit

**Disposition: GAPS.** The fresh risk:high reviewer independently verified Task linkage, authorization chronology, tests-first expected-red history, the surgical correction, production separation, every acceptance criterion, live GET-only behavior, no test/check weakening, exact ownership, the 380-line budget, governance safety, deviation honesty, and final CI run https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/31998430977 at exact head `e6e7ad68abcaa40b5b68993426fca74148b61735` with all five jobs successful.

The sole gap is review-gate provenance: this app surface exposes the completed Rubber Duck child agents (`tests-first-duck`, `tests-first-duck-final`, and `implementation-duck`, owned by worker session `fe292f8a-6ed5-4b6b-8fce-1ae21d500ee5`) but supplied no independently inspectable GitHub run/session URL or immutable timestamp artifact. The reviewer therefore treats both PASS statements above as attestation-only and requires durable historical references proving the first gate preceded the fixture-only commit and the second followed deterministic verification. A new run cannot substitute for missing historical chronology.

The requester explicitly accepted this disclosed provenance limitation as a Task #99 exception: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/99#issuecomment-5312304763. This human decision accepts the app-local PASS attestations without rewriting the fresh reviewer `GAPS` disposition, inventing chronology, or treating a later review as historical proof. All other gates remain unchanged.

## Deviations

During the initial local production implementation, the focused wall exposed an impossible blanket test condition: the Plan phrase `persistence failure ... before writes` could be read to forbid the intentionally attempted variable write itself, while the issue acceptance criterion and the Plan's variable-before-ruleset sequence require that POST/PATCH attempt to fail and then prohibit any ruleset write. The supervisor and Epic parent clarified the existing contract without changing the Plan. Commit `0951ae6` surgically requires exactly one failed variable create/update attempt and zero later ruleset/probe mutation; discovery/read failures retain the original zero-write helper. This correction was committed separately before the production commit, but it did not predate the initial local production edit. The original tests-only commit and expected-red run remain preserved.

No implementation deviation from the clarified Task contract remains.

## Follow-ups

No implementation follow-up. Readiness awaits supervisor independent final-ledger verification and Epic-parent report. Serialized followers #96 and #97 remain blocked and untouched.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and is linked above.
- [x] Diff stays inside the issue's **File ownership** paths.
- [x] Every command in the issue's **Verification** section was run; output captured above.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [ ] Record-before-report comment posted on the Task issue (supervisor-owned ritual).
- [x] All persistent artifacts in this PR are English-only.