### PR TITLE
Reconcile canonical rulesets to declared profiles

### DIFF
--- a/.github/scripts/setup-ruleset.sh
+++ b/.github/scripts/setup-ruleset.sh
@@ -58,6 +58,7 @@ Options:
   --profile <solo|team>    Persist explicit governance intent and create a
                            fresh profile ruleset. Existing rulesets require
                            separate reconciliation.
+  --reconcile              Require --profile and reconcile one canonical same-name ruleset.
   --dry-run                Print the request JSON body to stdout and exit
                            without making any API call.
   -h, --help               Show this help and exit.
@@ -79,6 +80,7 @@ ENFORCEMENT="disabled"
 NAME="scaffold-branch-protection"
 DRY_RUN="false"
 PROFILE=""
+RECONCILE="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -105,6 +107,7 @@ while [[ $# -gt 0 ]]; do
       shift 2 ;;
     --dry-run)
       DRY_RUN="true"; shift ;;
+    --reconcile) RECONCILE="true"; shift ;;
     -h|--help)
       usage; exit 0 ;;
     *)
@@ -112,6 +115,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+[[ "$RECONCILE" != "true" || -n "$PROFILE" ]] || { echo "error: --reconcile requires an explicit --profile" >&2; exit 2; }
 command -v jq >/dev/null 2>&1 || { echo "error: jq not found on PATH" >&2; exit 1; }
 
 # Build the request body with jq so every value is safely quoted. `$name`,
@@ -161,7 +165,7 @@ PAYLOAD="$(jq -n \
   }')"
 
 if [[ -n "$PROFILE" ]]; then
-  if [[ "$PROFILE" == "solo" && "$DRY_RUN" == "true" ]]; then
+  if [[ "$PROFILE" == "solo" && "$DRY_RUN" == "true" && "$RECONCILE" != "true" ]]; then
     echo "dry-run: explicit solo candidate; no API call made." >&2
     printf '%s\n' "$PAYLOAD"
     exit 0
@@ -179,6 +183,7 @@ if [[ -n "$PROFILE" ]]; then
     gh api user --jq .login >/dev/null 2>&1 \
       || { echo "error: gh is not authenticated" >&2; exit 1; }
   fi
+  if [[ "$DRY_RUN" != "true" || "$RECONCILE" == "true" ]]; then
   if ! RULESETS_JSON="$(gh api "repos/$REPO/rulesets")"; then
     echo "error: could not list rulesets for $REPO; aborting before writes." >&2
     exit 1
@@ -191,6 +196,8 @@ if [[ -n "$PROFILE" ]]; then
   }
   EXISTING_ID="$(printf '%s' "$RULESETS_JSON" \
     | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].id // empty')"
+  [[ "$RECONCILE" != "true" || "$MATCH_COUNT" -eq 1 ]] || { echo "error: --reconcile requires exactly one same-name ruleset." >&2; exit 1; }
+  [[ "$RECONCILE" == "true" || "$MATCH_COUNT" -eq 0 ]] || { echo "error: same-name ruleset requires --reconcile." >&2; exit 1; }
   EXISTING_DETAIL=""
   if [[ -n "$EXISTING_ID" ]]; then
     if ! EXISTING_DETAIL="$(gh api "repos/$REPO/rulesets/$EXISTING_ID")"; then
@@ -234,6 +241,7 @@ if [[ -n "$PROFILE" ]]; then
       echo "error: existing ruleset is noncanonical or malformed; refusing customization." >&2
       exit 1
     fi
+  fi
   fi
 
   if [[ "$PROFILE" == "team" ]]; then

--- a/.github/scripts/setup-ruleset.sh
+++ b/.github/scripts/setup-ruleset.sh
@@ -178,14 +178,60 @@ if [[ -n "$PROFILE" ]]; then
   if [[ "$DRY_RUN" != "true" ]]; then
     gh api user --jq .login >/dev/null 2>&1 \
       || { echo "error: gh is not authenticated" >&2; exit 1; }
-    if ! RULESETS_JSON="$(gh api "repos/$REPO/rulesets")"; then
-      echo "error: could not list rulesets for $REPO; aborting before writes." >&2
+  fi
+  if ! RULESETS_JSON="$(gh api "repos/$REPO/rulesets")"; then
+    echo "error: could not list rulesets for $REPO; aborting before writes." >&2
+    exit 1
+  fi
+  MATCH_COUNT="$(printf '%s' "$RULESETS_JSON" \
+    | jq --arg name "$NAME" '[.[] | select(.name == $name)] | length')"
+  [[ "$MATCH_COUNT" -le 1 ]] || {
+    echo "error: multiple same-name rulesets found; expected exactly one." >&2
+    exit 1
+  }
+  EXISTING_ID="$(printf '%s' "$RULESETS_JSON" \
+    | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].id // empty')"
+  EXISTING_DETAIL=""
+  if [[ -n "$EXISTING_ID" ]]; then
+    if ! EXISTING_DETAIL="$(gh api "repos/$REPO/rulesets/$EXISTING_ID")"; then
+      echo "error: ruleset detail read failed; aborting before writes." >&2
       exit 1
     fi
-    EXISTING_ID="$(printf '%s' "$RULESETS_JSON" \
-      | jq -r --arg name "$NAME" '[.[] | select(.name == $name)][0].id // empty')"
-    if [[ -n "$EXISTING_ID" ]]; then
-      echo "error: ruleset '$NAME' already exists; explicit-profile reconciliation required." >&2
+    if ! printf '%s' "$EXISTING_DETAIL" | jq -er \
+      --arg name "$NAME" --arg id "$EXISTING_ID" --arg checks "$CHECKS" '
+      ($checks | split(",") | map(gsub("^\\s+|\\s+$"; ""))
+       | map(select(length > 0)) | sort) as $want
+      | [.rules[] | select(.type == "pull_request")] as $pr
+      | [.rules[] | select(.type == "required_status_checks")] as $rs
+      | ($rs[0].parameters.required_status_checks // []) as $got
+      | ($pr[0].parameters | del(.allowed_merge_methods,.required_reviewers)) as $prp
+      | ($rs[0].parameters | del(.do_not_enforce_on_create)) as $rsp
+      | select((.id | tostring) == $id and .name == $name and .target == "branch"
+          and (.enforcement == "active" or .enforcement == "disabled")
+          and .bypass_actors == [{actor_id:5,actor_type:"RepositoryRole",bypass_mode:"pull_request"}]
+          and .conditions == {ref_name:{include:["~DEFAULT_BRANCH"],exclude:[]}}
+          and (.rules | length) == 2 and ($pr | length) == 1 and ($rs | length) == 1
+          and ($pr[0].parameters.allowed_merge_methods? // ["merge","squash","rebase"])
+              == ["merge","squash","rebase"]
+          and ($pr[0].parameters.required_reviewers? // []) == []
+          and ($rs[0].parameters.do_not_enforce_on_create? // false) == false
+          and ($rsp | keys | sort) == ["required_status_checks","strict_required_status_checks_policy"]
+          and ([$got[].context] | sort) == $want and ($got | length) == ($want | length))
+      | if $prp == {required_approving_review_count:1,
+            dismiss_stale_reviews_on_push:false,require_code_owner_review:false,
+            require_last_push_approval:false,required_review_thread_resolution:false}
+          and $rs[0].parameters.strict_required_status_checks_policy == false
+          and all($got[]; (keys | sort) == ["context"]) then "solo"
+        elif $prp == {required_approving_review_count:1,
+            dismiss_stale_reviews_on_push:true,require_code_owner_review:true,
+            require_last_push_approval:true,required_review_thread_resolution:true}
+          and $rs[0].parameters.strict_required_status_checks_policy == true
+          and all($got[]; (keys | sort) == ["context","integration_id"]
+            and (.integration_id | type) == "number" and .integration_id >= 0
+            and (.integration_id | floor) == .integration_id)
+          and ([$got[].integration_id] | unique | length) == 1 then "team"
+        else empty end' >/dev/null; then
+      echo "error: existing ruleset is noncanonical or malformed; refusing customization." >&2
       exit 1
     fi
   fi
@@ -276,10 +322,30 @@ EOF
     fi
   fi
 
-  if ! RESPONSE="$(printf '%s' "$PAYLOAD" \
+  if [[ -n "$EXISTING_ID" ]]; then
+    EXISTING_ENFORCEMENT="$(printf '%s' "$EXISTING_DETAIL" | jq -r '.enforcement')"
+    if [[ "$PROFILE" == "solo" ]]; then
+      if [[ "$EXISTING_ENFORCEMENT" != "$ENFORCEMENT" ]]; then
+        gh api --method PUT "repos/$REPO/rulesets/$EXISTING_ID" \
+          -f enforcement="$ENFORCEMENT" >/dev/null
+      fi
+    elif ! printf '%s' "$EXISTING_DETAIL" | jq -e --argjson wanted "$PAYLOAD" '
+      {name,target,enforcement,bypass_actors,conditions,
+       rules:(.rules | map(
+         if .type == "pull_request" then
+           .parameters |= del(.allowed_merge_methods,.required_reviewers)
+         elif .type == "required_status_checks" then
+           .parameters |= del(.do_not_enforce_on_create)
+         else . end))} == $wanted' >/dev/null; then
+      printf '%s' "$PAYLOAD" \
+        | gh api --method PUT "repos/$REPO/rulesets/$EXISTING_ID" --input - >/dev/null
+    fi
+    echo "Reconciled ruleset '$NAME' (id: $EXISTING_ID) on $REPO."
+    exit 0
+  elif ! RESPONSE="$(printf '%s' "$PAYLOAD" \
     | gh api --method POST "repos/$REPO/rulesets" --input -)"; then
-    echo "error: governance intent persisted, but ruleset creation failed." >&2
-    exit 1
+      echo "error: governance intent persisted, but ruleset creation failed." >&2
+      exit 1
   fi
   RULESET_ID="$(printf '%s' "$RESPONSE" | jq -r '.id')"
   echo "Created ruleset '$NAME' (id: $RULESET_ID, enforcement: $ENFORCEMENT) on $REPO."

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -147,7 +147,8 @@ existing_profile_fixtures() {
 
 detail_fails_closed() {
   local name="$1" profile="$2" rc=0 out
-  out="$(run_script -R acme/widget --profile "$profile" 2>&1)" || rc=$?
+  shift 2
+  out="$(run_script -R acme/widget --profile "$profile" "$@" 2>&1)" || rc=$?
   if [ "$rc" -eq 1 ] \
      && printf '%s\n' "$out" | grep -Eqi 'canonical|custom|detail|malformed' \
      && grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
@@ -466,6 +467,23 @@ if grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
 else
   t_fail "existing-profile dry-run reads detail without mutation"
 fi
+
+existing_profile_fixtures solo
+rc=0
+out="$(run_script -R acme/widget --profile solo --dry-run 2>&1)" || rc=$?
+if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -Eqi 'dry-run.*candidate|no.op' \
+   && [ "$(cat "$GH_CALLS")" = "$(printf '%s\n' \
+     'api repos/acme/widget/rulesets' 'api repos/acme/widget/rulesets/42')" ] \
+   && no_profile_writes; then
+  t_ok "existing canonical solo dry-run validates detail with GET-only candidate output"
+else
+  t_fail "existing canonical solo dry-run validates detail with GET-only candidate output"
+fi
+
+existing_profile_fixtures solo
+jq '.target = "tag"' "$GH_FIXTURES/ruleset-detail.json" > "$GH_FIXTURES/detail.tmp"
+mv "$GH_FIXTURES/detail.tmp" "$GH_FIXTURES/ruleset-detail.json"
+detail_fails_closed "noncanonical solo dry-run fails closed after detail GET" solo --dry-run
 
 # Exact shape: each single mutation is adopter-owned and must fail closed.
 while IFS='|' read -r name base filter; do

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -17,8 +17,8 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 # Recording stub: every invocation lands in $GH_CALLS (one line of argv per
-# call); list responses come from $GH_FIXTURES/rulesets.json (absent file
-# models a failed list); a POST body is captured to $GH_FIXTURES/posted.json.
+# call); responses come from fixed files under $GH_FIXTURES; request bodies
+# are captured so reconciliation shape and write ordering stay observable.
 export GH_FIXTURES="$WORK/fixtures"
 export GH_CALLS="$WORK/gh-calls.log"
 export GH_ALL_CALLS="$WORK/gh-all-calls.log"
@@ -48,9 +48,14 @@ case "$*" in
     cat > "$GH_FIXTURES/variable-written.json"; echo '{}' ;;
   "api --method PATCH repos/"*"/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE --input -")
     cat > "$GH_FIXTURES/variable-written.json"; echo '{}' ;;
+  "api --method PUT repos/"*"/rulesets/"*" --input -")
+    cat > "$GH_FIXTURES/put.json"; echo '{"id":42}' ;;
   "api repos/"*"/rulesets")
     [ -f "$GH_FIXTURES/rulesets.json" ] || exit 1
     cat "$GH_FIXTURES/rulesets.json" ;;
+  "api repos/"*"/rulesets/"*)
+    [ -f "$GH_FIXTURES/ruleset-detail.json" ] || exit 1
+    cat "$GH_FIXTURES/ruleset-detail.json" ;;
   "api --method PUT repos/"*"/rulesets/"*) echo '{}' ;;
   "api --method POST repos/"*"/rulesets --input -")
     cat > "$GH_FIXTURES/posted.json"; echo '{"id": 999}' ;;
@@ -68,7 +73,7 @@ reset_calls() { : > "$GH_CALLS"; }
 run_script() { bash "$SCRIPT" "$@" < /dev/null; }
 
 no_profile_writes() {
-  ! grep -Eq -- '--method (POST|PUT|PATCH).*(actions/variables|rulesets)' "$GH_CALLS"
+  ! grep -Eq -- '--method (POST|PUT|PATCH|DELETE).*(actions/variables|rulesets)' "$GH_CALLS"
 }
 
 profile_fixtures() {
@@ -76,7 +81,8 @@ profile_fixtures() {
   unset GH_FAIL GH_FAIL_EXACT GH_FAIL_MESSAGE
   export GH_VARIABLE=missing
   rm -f "$GH_FIXTURES/variable.json" "$GH_FIXTURES/variable-written.json" \
-    "$GH_FIXTURES/posted.json"
+    "$GH_FIXTURES/posted.json" "$GH_FIXTURES/put.json" \
+    "$GH_FIXTURES/ruleset-detail.json"
   echo '[]' > "$GH_FIXTURES/rulesets.json"
   echo '{"default_branch":"trunk"}' > "$GH_FIXTURES/repo.json"
   cat > "$GH_FIXTURES/checkruns.json" <<'JSON'
@@ -100,6 +106,72 @@ team_fails_closed() {
     t_fail "$name (rc=$rc; expected failure before writes)"
     printf '%s\n' "$out" | sed 's/^/    # /'
     sed 's/^/    # call: /' "$GH_CALLS"
+  fi
+}
+
+canonical_detail() {
+  local profile="$1" enforcement="${2:-disabled}" app="${3:-15368}"
+  jq -n --arg profile "$profile" --arg enforcement "$enforcement" \
+    --argjson app "$app" '{
+      id: 42, name: "scaffold-branch-protection", target: "branch",
+      enforcement: $enforcement,
+      bypass_actors: [{actor_id: 5, actor_type: "RepositoryRole",
+                       bypass_mode: "pull_request"}],
+      conditions: {ref_name: {include: ["~DEFAULT_BRANCH"], exclude: []}},
+      rules: [
+        {type: "pull_request", parameters: {
+          required_approving_review_count: 1,
+          dismiss_stale_reviews_on_push: ($profile == "team"),
+          require_code_owner_review: ($profile == "team"),
+          require_last_push_approval: ($profile == "team"),
+          required_review_thread_resolution: ($profile == "team")}},
+        {type: "required_status_checks", parameters: {
+          strict_required_status_checks_policy: ($profile == "team"),
+          required_status_checks:
+            (["quality","task-ritual","scaffold-self-check","copilot-surface"]
+             | map({context: .})
+             | if $profile == "team"
+               then map(. + {integration_id: $app}) else . end)}}
+      ]
+    }'
+}
+
+existing_profile_fixtures() {
+  local profile="$1" enforcement="${2:-disabled}" app="${3:-15368}"
+  profile_fixtures
+  printf '[{"id":42,"name":"scaffold-branch-protection","enforcement":"%s"}]\n' \
+    "$enforcement" > "$GH_FIXTURES/rulesets.json"
+  canonical_detail "$profile" "$enforcement" "$app" \
+    > "$GH_FIXTURES/ruleset-detail.json"
+}
+
+detail_fails_closed() {
+  local name="$1" rc=0 out
+  out="$(run_script -R acme/widget --profile team 2>&1)" || rc=$?
+  if [ "$rc" -eq 1 ] \
+     && printf '%s\n' "$out" | grep -Eqi 'canonical|custom|detail|malformed' \
+     && grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
+     && no_profile_writes; then
+    t_ok "$name"
+  else
+    t_fail "$name (detail must be read and rejected before writes)"
+  fi
+}
+
+assert_team_put() {
+  local name="$1" enforcement="$2" app="$3"
+  if jq -e --arg enforcement "$enforcement" --argjson app "$app" '
+       .id == null and .enforcement == $enforcement
+       and all(.rules[] | select(.type == "pull_request").parameters;
+         .dismiss_stale_reviews_on_push and .require_code_owner_review
+         and .require_last_push_approval and .required_review_thread_resolution)
+       and all(.rules[] | select(.type == "required_status_checks").parameters;
+         .strict_required_status_checks_policy
+         and all(.required_status_checks[]; .integration_id == $app))
+     ' "$GH_FIXTURES/put.json" >/dev/null; then
+    t_ok "$name"
+  else
+    t_fail "$name"
   fi
 }
 
@@ -282,20 +354,123 @@ else
   t_fail "team payload binds every context and persists exact team intent"
 fi
 
-# --- explicit profiles: refusal, discovery, and persistence failures --------
+# --- explicit profiles: existing canonical reconciliation -------------------
 
-profile_fixtures
-echo '[{"id":42,"name":"scaffold-branch-protection","enforcement":"disabled"}]' \
-  > "$GH_FIXTURES/rulesets.json"
-expect_rc_grep 1 'reconciliation|required.*existing' \
-  "explicit profile refuses an existing same-name ruleset" \
-  run_script -R acme/widget --profile solo
-if grep -q -- 'api repos/acme/widget/rulesets' "$GH_CALLS" \
-   && no_profile_writes; then
-  t_ok "same-name refusal happens before all profile writes"
+existing_profile_fixtures solo
+expect_rc 0 "canonical solo upgrades in place to explicit team" \
+  run_script -R acme/widget --profile team
+assert_team_put "team upgrade writes the complete canonical team body" disabled 15368
+if [ "$(grep -nE 'rulesets/42|repos/acme/widget$|check-runs|actions/variables|--method PUT' \
+          "$GH_CALLS" | cut -d: -f2-)" = "$(printf '%s\n' \
+     'api repos/acme/widget/rulesets/42' \
+     'api repos/acme/widget' \
+     'api repos/acme/widget/commits/trunk/check-runs?filter=latest&per_page=100 --paginate' \
+     'api repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' \
+     'api --method POST repos/acme/widget/actions/variables --input -' \
+     'api --method PUT repos/acme/widget/rulesets/42 --input -')" ]; then
+  t_ok "team upgrade completes every read and persists intent before ruleset PUT"
 else
-  t_fail "same-name refusal happens before all profile writes"
+  t_fail "team upgrade completes every read and persists intent before ruleset PUT"
 fi
+
+existing_profile_fixtures team disabled 77
+expect_rc 0 "canonical team refreshes changed source and enforcement" \
+  run_script -R acme/widget --profile team --enforcement active
+assert_team_put "team refresh uses observed source and requested enforcement" active 15368
+
+existing_profile_fixtures team active
+expect_rc 0 "exact canonical team match is idempotent" \
+  run_script -R acme/widget --profile team --enforcement active
+if grep -q 'rulesets/42' "$GH_CALLS" \
+   && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
+  t_ok "exact team match reads detail and performs no ruleset write"
+else
+  t_fail "exact team match reads detail and performs no ruleset write"
+fi
+
+existing_profile_fixtures team active
+expect_rc 0 "explicit solo accepts canonical team without downgrade" \
+  run_script -R acme/widget --profile solo --enforcement active
+if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
+  t_ok "solo persists intent without rewriting canonical team controls"
+else
+  t_fail "solo persists intent without rewriting canonical team controls"
+fi
+
+existing_profile_fixtures team disabled
+expect_rc 0 "solo may update only enforcement on canonical team" \
+  run_script -R acme/widget --profile solo --enforcement active
+if grep -q -- '--method PUT repos/acme/widget/rulesets/42 -f enforcement=active' \
+     "$GH_CALLS" \
+   && ! grep -q -- '--method PUT repos/acme/widget/rulesets/42 --input -' \
+     "$GH_CALLS"; then
+  t_ok "solo enforcement change never submits rules or drops team hardening"
+else
+  t_fail "solo enforcement change never submits rules or drops team hardening"
+fi
+
+existing_profile_fixtures team
+expect_rc 0 "existing canonical team dry-run validates with GET calls only" \
+  run_script -R acme/widget --profile team --dry-run
+if grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
+   && no_profile_writes; then
+  t_ok "existing-profile dry-run reads detail without mutation"
+else
+  t_fail "existing-profile dry-run reads detail without mutation"
+fi
+
+# Exact shape: each single mutation is adopter-owned and must fail closed.
+while IFS='|' read -r name base filter; do
+  existing_profile_fixtures "$base"
+  jq "$filter" "$GH_FIXTURES/ruleset-detail.json" \
+    > "$GH_FIXTURES/detail.tmp"
+  mv "$GH_FIXTURES/detail.tmp" "$GH_FIXTURES/ruleset-detail.json"
+  detail_fails_closed "$name"
+done <<'NONCANONICAL'
+tag target is noncanonical|solo|.target = "tag"
+changed include is noncanonical|solo|.conditions.ref_name.include = ["refs/heads/main"]
+extra exclude is noncanonical|solo|.conditions.ref_name.exclude = ["refs/heads/dev"]
+extra bypass is noncanonical|solo|.bypass_actors += [{actor_id:4,actor_type:"RepositoryRole",bypass_mode:"pull_request"}]
+changed bypass mode is noncanonical|solo|.bypass_actors[0].bypass_mode = "always"
+extra rule is noncanonical|solo|.rules += [{type:"deletion"}]
+duplicate rule is noncanonical|solo|.rules += [.rules[0]]
+missing rule is noncanonical|solo|.rules |= map(select(.type != "pull_request"))
+extra context is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks) += [{context:"extra"}]
+renamed context is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].context) = "renamed"
+duplicate context is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks) |= . + [.[0]]
+mixed review controls are noncanonical|solo|(.rules[]|select(.type=="pull_request").parameters.dismiss_stale_reviews_on_push) = true
+mixed strictness is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.strict_required_status_checks_policy) = true
+solo source binding is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = 15368
+team missing source is noncanonical|team|del(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id)
+team mixed source is noncanonical|team|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = 42
+NONCANONICAL
+
+# Zero matches intentionally remains the #95 fresh-create path tested above.
+profile_fixtures
+printf '%s\n' \
+  '[{"id":42,"name":"scaffold-branch-protection","enforcement":"disabled"},' \
+  '{"id":43,"name":"scaffold-branch-protection","enforcement":"disabled"}]' \
+  > "$GH_FIXTURES/rulesets.json"
+expect_rc_grep 1 'multiple|duplicate|exactly one' \
+  "multiple same-name rulesets fail closed" \
+  run_script -R acme/widget --profile team
+if no_profile_writes; then
+  t_ok "multiple same-name rulesets cause zero writes"
+else
+  t_fail "multiple same-name rulesets cause zero writes"
+fi
+
+existing_profile_fixtures team
+rm -f "$GH_FIXTURES/ruleset-detail.json"
+detail_fails_closed "failed ruleset detail read blocks all writes"
+
+existing_profile_fixtures team
+printf '%s\n' '{"id":42,"name":"scaffold-branch-protection"}' \
+  > "$GH_FIXTURES/ruleset-detail.json"
+detail_fails_closed "malformed ruleset detail blocks all writes"
+
+# --- explicit profiles: discovery and persistence failures ------------------
 
 profile_fixtures
 export GH_FAIL_EXACT='api repos/acme/widget'

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -148,7 +148,7 @@ existing_profile_fixtures() {
 detail_fails_closed() {
   local name="$1" profile="$2" rc=0 out
   shift 2
-  out="$(run_script -R acme/widget --profile "$profile" "$@" 2>&1)" || rc=$?
+  out="$(run_script -R acme/widget --profile "$profile" --reconcile "$@" 2>&1)" || rc=$?
   if [ "$rc" -eq 1 ] \
      && printf '%s\n' "$out" | grep -Eqi 'canonical|custom|detail|malformed' \
      && grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
@@ -190,14 +190,14 @@ team_refresh_case() {
   local run_name="$1" body_name="$2" old_enforcement="$3"
   local old_app="$4" requested_enforcement="$5"
   existing_profile_fixtures team "$old_enforcement" "$old_app"
-  expect_rc 0 "$run_name" run_script -R acme/widget --profile team \
+  expect_rc 0 "$run_name" run_script -R acme/widget --profile team --reconcile \
     --enforcement "$requested_enforcement"
   assert_team_put "$body_name" "$requested_enforcement" 15368
 }
 
 variable_write_fails_closed() {
-  local name="$1" endpoint="$2" profile="${3:-team}" rc=0 out
-  out="$(run_script -R acme/widget --profile "$profile" 2>&1)" || rc=$?
+  local name="$1" endpoint="$2" profile="${3:-team}" rc=0 out reconcile="${3:+--reconcile}"
+  out="$(run_script -R acme/widget --profile "$profile" ${reconcile:+"$reconcile"} 2>&1)" || rc=$?
   if [ "$rc" -eq 1 ] \
      && printf '%s\n' "$out" | grep -Eqi 'could not (create|update).*variable' \
      && [ "$(grep -c -- "$endpoint" "$GH_CALLS")" -eq 1 ] \
@@ -385,7 +385,7 @@ fi
 
 existing_profile_fixtures solo
 expect_rc 0 "canonical solo upgrades in place to explicit team" \
-  run_script -R acme/widget --profile team
+  run_script -R acme/widget --profile team --reconcile
 assert_team_put "team upgrade writes the complete canonical team body" disabled 15368
 if [ "$(grep -nE 'rulesets/42|repos/acme/widget$|check-runs|actions/variables|--method PUT' \
           "$GH_CALLS" | cut -d: -f2-)" = "$(printf '%s\n' \
@@ -409,7 +409,7 @@ team_refresh_case "team refreshes when only requested enforcement differs" \
 
 existing_profile_fixtures team active
 expect_rc 0 "exact canonical team match is idempotent" \
-  run_script -R acme/widget --profile team --enforcement active
+  run_script -R acme/widget --profile team --enforcement active --reconcile
 if jq -e '.value == "team"' "$GH_FIXTURES/variable-written.json" >/dev/null \
    && grep -q 'rulesets/42' "$GH_CALLS" \
    && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
@@ -420,7 +420,7 @@ fi
 
 existing_profile_fixtures solo active
 expect_rc 0 "exact canonical solo match is idempotent" \
-  run_script -R acme/widget --profile solo --enforcement active
+  run_script -R acme/widget --profile solo --enforcement active --reconcile
 if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
    && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
   t_ok "exact solo match persists solo intent and performs no ruleset write"
@@ -430,7 +430,7 @@ fi
 
 existing_profile_fixtures team active
 expect_rc 0 "explicit solo accepts canonical team without downgrade" \
-  run_script -R acme/widget --profile solo --enforcement active
+  run_script -R acme/widget --profile solo --enforcement active --reconcile
 if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
    && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
   t_ok "solo persists intent without rewriting canonical team controls"
@@ -440,7 +440,7 @@ fi
 
 existing_profile_fixtures team active 77
 expect_rc 0 "explicit solo ignores canonical team source drift" \
-  run_script -R acme/widget --profile solo --enforcement active
+  run_script -R acme/widget --profile solo --enforcement active --reconcile
 if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
    && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
   t_ok "solo source drift persists solo intent with zero ruleset writes"
@@ -450,7 +450,7 @@ fi
 
 existing_profile_fixtures team disabled
 expect_rc 0 "solo may update only enforcement on canonical team" \
-  run_script -R acme/widget --profile solo --enforcement active
+  run_script -R acme/widget --profile solo --enforcement active --reconcile
 if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
    && [ "$(grep -E 'rulesets/42|actions/variables|--method PUT' "$GH_CALLS")" \
         = "$(printf '%s\n' \
@@ -467,7 +467,7 @@ fi
 
 existing_profile_fixtures team
 expect_rc 0 "existing canonical team dry-run validates with GET calls only" \
-  run_script -R acme/widget --profile team --dry-run
+  run_script -R acme/widget --profile team --dry-run --reconcile
 if grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
    && no_profile_writes; then
   t_ok "existing-profile dry-run reads detail without mutation"
@@ -491,7 +491,7 @@ existing_profile_fixtures solo
 jq '.target = "tag"' "$GH_FIXTURES/ruleset-detail.json" > "$GH_FIXTURES/detail.tmp"
 mv "$GH_FIXTURES/detail.tmp" "$GH_FIXTURES/ruleset-detail.json"
 detail_fails_closed "noncanonical solo dry-run fails closed after detail GET" \
-  solo --reconcile --dry-run
+  solo --dry-run
 
 # Exact shape: each single mutation is adopter-owned and must fail closed.
 while IFS='|' read -r name base filter; do
@@ -530,7 +530,7 @@ printf '%s\n' \
   > "$GH_FIXTURES/rulesets.json"
 expect_rc_grep 1 'multiple|duplicate|exactly one' \
   "multiple same-name rulesets fail closed" \
-  run_script -R acme/widget --profile team
+  run_script -R acme/widget --profile team --reconcile
 if no_profile_writes; then
   t_ok "multiple same-name rulesets cause zero writes"
 else

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -220,6 +220,13 @@ expect_rc_grep 2 "must be 'active' or 'disabled'" \
 expect_rc_grep 2 "profile.*solo.*team" \
   "invalid --profile is a usage error" \
   run_script --profile pirate
+reset_calls
+rc=0; out="$(run_script --reconcile 2>&1)" || rc=$?
+if [ "$rc" -eq 2 ] && printf '%s\n' "$out" | grep -Eqi 'reconcile.*profile|profile.*reconcile' \
+   && [ ! -s "$GH_CALLS" ]; then
+  t_ok "--reconcile requires an explicit profile before gh calls"
+else t_fail "--reconcile requires an explicit profile before gh calls"
+fi
 
 # --- dry-run: valid payload, zero gh calls ---------------------------------
 
@@ -470,7 +477,7 @@ fi
 
 existing_profile_fixtures solo
 rc=0
-out="$(run_script -R acme/widget --profile solo --dry-run 2>&1)" || rc=$?
+out="$(run_script -R acme/widget --profile solo --reconcile --dry-run 2>&1)" || rc=$?
 if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -Eqi 'dry-run.*candidate|no.op' \
    && [ "$(cat "$GH_CALLS")" = "$(printf '%s\n' \
      'api repos/acme/widget/rulesets' 'api repos/acme/widget/rulesets/42')" ] \
@@ -483,7 +490,8 @@ fi
 existing_profile_fixtures solo
 jq '.target = "tag"' "$GH_FIXTURES/ruleset-detail.json" > "$GH_FIXTURES/detail.tmp"
 mv "$GH_FIXTURES/detail.tmp" "$GH_FIXTURES/ruleset-detail.json"
-detail_fails_closed "noncanonical solo dry-run fails closed after detail GET" solo --dry-run
+detail_fails_closed "noncanonical solo dry-run fails closed after detail GET" \
+  solo --reconcile --dry-run
 
 # Exact shape: each single mutation is adopter-owned and must fail closed.
 while IFS='|' read -r name base filter; do

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -146,8 +146,8 @@ existing_profile_fixtures() {
 }
 
 detail_fails_closed() {
-  local name="$1" rc=0 out
-  out="$(run_script -R acme/widget --profile team 2>&1)" || rc=$?
+  local name="$1" profile="$2" rc=0 out
+  out="$(run_script -R acme/widget --profile "$profile" 2>&1)" || rc=$?
   if [ "$rc" -eq 1 ] \
      && printf '%s\n' "$out" | grep -Eqi 'canonical|custom|detail|malformed' \
      && grep -q 'api repos/acme/widget/rulesets/42' "$GH_CALLS" \
@@ -160,14 +160,24 @@ detail_fails_closed() {
 
 assert_team_put() {
   local name="$1" enforcement="$2" app="$3"
-  if jq -e --arg enforcement "$enforcement" --argjson app "$app" '
-       .id == null and .enforcement == $enforcement
-       and all(.rules[] | select(.type == "pull_request").parameters;
-         .dismiss_stale_reviews_on_push and .require_code_owner_review
-         and .require_last_push_approval and .required_review_thread_resolution)
-       and all(.rules[] | select(.type == "required_status_checks").parameters;
-         .strict_required_status_checks_policy
-         and all(.required_status_checks[]; .integration_id == $app))
+  if [ -f "$GH_FIXTURES/put.json" ] \
+     && jq -e --arg enforcement "$enforcement" --argjson app "$app" '
+       .name == "scaffold-branch-protection" and .target == "branch"
+       and .enforcement == $enforcement
+       and .bypass_actors == [{actor_id:5, actor_type:"RepositoryRole",
+                               bypass_mode:"pull_request"}]
+       and .conditions == {ref_name:{include:["~DEFAULT_BRANCH"],exclude:[]}}
+       and [.rules[].type] == ["pull_request","required_status_checks"]
+       and (.rules[0].parameters == {
+         required_approving_review_count:1,
+         dismiss_stale_reviews_on_push:true,
+         require_code_owner_review:true,
+         require_last_push_approval:true,
+         required_review_thread_resolution:true})
+       and .rules[1].parameters.strict_required_status_checks_policy
+       and (.rules[1].parameters.required_status_checks | sort_by(.context))
+         == (["copilot-surface","quality","scaffold-self-check","task-ritual"]
+             | map({context:.,integration_id:$app}))
      ' "$GH_FIXTURES/put.json" >/dev/null; then
     t_ok "$name"
   else
@@ -176,8 +186,8 @@ assert_team_put() {
 }
 
 variable_write_fails_closed() {
-  local name="$1" endpoint="$2" rc=0 out
-  out="$(run_script -R acme/widget --profile team 2>&1)" || rc=$?
+  local name="$1" endpoint="$2" profile="${3:-team}" rc=0 out
+  out="$(run_script -R acme/widget --profile "$profile" 2>&1)" || rc=$?
   if [ "$rc" -eq 1 ] \
      && printf '%s\n' "$out" | grep -Eqi 'could not (create|update).*variable' \
      && [ "$(grep -c -- "$endpoint" "$GH_CALLS")" -eq 1 ] \
@@ -381,11 +391,22 @@ assert_team_put "team refresh uses observed source and requested enforcement" ac
 existing_profile_fixtures team active
 expect_rc 0 "exact canonical team match is idempotent" \
   run_script -R acme/widget --profile team --enforcement active
-if grep -q 'rulesets/42' "$GH_CALLS" \
+if jq -e '.value == "team"' "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && grep -q 'rulesets/42' "$GH_CALLS" \
    && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
-  t_ok "exact team match reads detail and performs no ruleset write"
+  t_ok "exact team match persists team intent and performs no ruleset write"
 else
-  t_fail "exact team match reads detail and performs no ruleset write"
+  t_fail "exact team match persists team intent and performs no ruleset write"
+fi
+
+existing_profile_fixtures solo active
+expect_rc 0 "exact canonical solo match is idempotent" \
+  run_script -R acme/widget --profile solo --enforcement active
+if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
+  t_ok "exact solo match persists solo intent and performs no ruleset write"
+else
+  t_fail "exact solo match persists solo intent and performs no ruleset write"
 fi
 
 existing_profile_fixtures team active
@@ -401,13 +422,18 @@ fi
 existing_profile_fixtures team disabled
 expect_rc 0 "solo may update only enforcement on canonical team" \
   run_script -R acme/widget --profile solo --enforcement active
-if grep -q -- '--method PUT repos/acme/widget/rulesets/42 -f enforcement=active' \
-     "$GH_CALLS" \
+if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && [ "$(grep -E 'rulesets/42|actions/variables|--method PUT' "$GH_CALLS")" \
+        = "$(printf '%s\n' \
+       'api repos/acme/widget/rulesets/42' \
+       'api repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' \
+       'api --method POST repos/acme/widget/actions/variables --input -' \
+       'api --method PUT repos/acme/widget/rulesets/42 -f enforcement=active')" ] \
    && ! grep -q -- '--method PUT repos/acme/widget/rulesets/42 --input -' \
      "$GH_CALLS"; then
-  t_ok "solo enforcement change never submits rules or drops team hardening"
+  t_ok "solo intent persists before enforcement-only PUT without rule rewrite"
 else
-  t_fail "solo enforcement change never submits rules or drops team hardening"
+  t_fail "solo intent persists before enforcement-only PUT without rule rewrite"
 fi
 
 existing_profile_fixtures team
@@ -426,13 +452,14 @@ while IFS='|' read -r name base filter; do
   jq "$filter" "$GH_FIXTURES/ruleset-detail.json" \
     > "$GH_FIXTURES/detail.tmp"
   mv "$GH_FIXTURES/detail.tmp" "$GH_FIXTURES/ruleset-detail.json"
-  detail_fails_closed "$name"
+  detail_fails_closed "$name" "$base"
 done <<'NONCANONICAL'
 tag target is noncanonical|solo|.target = "tag"
 changed include is noncanonical|solo|.conditions.ref_name.include = ["refs/heads/main"]
 extra exclude is noncanonical|solo|.conditions.ref_name.exclude = ["refs/heads/dev"]
 extra bypass is noncanonical|solo|.bypass_actors += [{actor_id:4,actor_type:"RepositoryRole",bypass_mode:"pull_request"}]
 changed bypass mode is noncanonical|solo|.bypass_actors[0].bypass_mode = "always"
+changed approval count is noncanonical|solo|.rules[0].parameters.required_approving_review_count = 2
 extra rule is noncanonical|solo|.rules += [{type:"deletion"}]
 duplicate rule is noncanonical|solo|.rules += [.rules[0]]
 missing rule is noncanonical|solo|.rules |= map(select(.type != "pull_request"))
@@ -444,6 +471,8 @@ mixed strictness is noncanonical|solo|(.rules[]|select(.type=="required_status_c
 solo source binding is noncanonical|solo|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = 15368
 team missing source is noncanonical|team|del(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id)
 team mixed source is noncanonical|team|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = 42
+team null source is noncanonical|team|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = null
+team malformed source is noncanonical|team|(.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[0].integration_id) = "bad"
 NONCANONICAL
 
 # Zero matches intentionally remains the #95 fresh-create path tested above.
@@ -463,12 +492,36 @@ fi
 
 existing_profile_fixtures team
 rm -f "$GH_FIXTURES/ruleset-detail.json"
-detail_fails_closed "failed ruleset detail read blocks all writes"
+detail_fails_closed "failed team ruleset detail read blocks all writes" team
+
+existing_profile_fixtures solo
+rm -f "$GH_FIXTURES/ruleset-detail.json"
+detail_fails_closed "failed solo ruleset detail read blocks all writes" solo
 
 existing_profile_fixtures team
 printf '%s\n' '{"id":42,"name":"scaffold-branch-protection"}' \
   > "$GH_FIXTURES/ruleset-detail.json"
-detail_fails_closed "malformed ruleset detail blocks all writes"
+detail_fails_closed "malformed team ruleset detail blocks all writes" team
+
+existing_profile_fixtures solo
+printf '%s\n' '{"id":42,"name":"scaffold-branch-protection"}' \
+  > "$GH_FIXTURES/ruleset-detail.json"
+detail_fails_closed "malformed solo ruleset detail blocks all writes" solo
+
+existing_profile_fixtures solo
+export GH_FAIL_EXACT='api --method POST repos/acme/widget/actions/variables --input -'
+variable_write_fails_closed \
+  "existing solo variable create failure blocks later ruleset PUT" \
+  '--method POST repos/acme/widget/actions/variables' solo
+
+existing_profile_fixtures team
+export GH_VARIABLE=present
+echo '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"solo"}' \
+  > "$GH_FIXTURES/variable.json"
+export GH_FAIL_EXACT='api --method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE --input -'
+variable_write_fails_closed \
+  "existing team variable update failure blocks later ruleset PUT" \
+  '--method PATCH repos/acme/widget/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' team
 
 # --- explicit profiles: discovery and persistence failures ------------------
 

--- a/.github/scripts/tests/test-setup-ruleset.sh
+++ b/.github/scripts/tests/test-setup-ruleset.sh
@@ -185,6 +185,15 @@ assert_team_put() {
   fi
 }
 
+team_refresh_case() {
+  local run_name="$1" body_name="$2" old_enforcement="$3"
+  local old_app="$4" requested_enforcement="$5"
+  existing_profile_fixtures team "$old_enforcement" "$old_app"
+  expect_rc 0 "$run_name" run_script -R acme/widget --profile team \
+    --enforcement "$requested_enforcement"
+  assert_team_put "$body_name" "$requested_enforcement" 15368
+}
+
 variable_write_fails_closed() {
   local name="$1" endpoint="$2" profile="${3:-team}" rc=0 out
   out="$(run_script -R acme/widget --profile "$profile" 2>&1)" || rc=$?
@@ -383,10 +392,12 @@ else
   t_fail "team upgrade completes every read and persists intent before ruleset PUT"
 fi
 
-existing_profile_fixtures team disabled 77
-expect_rc 0 "canonical team refreshes changed source and enforcement" \
-  run_script -R acme/widget --profile team --enforcement active
-assert_team_put "team refresh uses observed source and requested enforcement" active 15368
+team_refresh_case "canonical team refreshes changed source and enforcement" \
+  "team refresh uses observed source and requested enforcement" disabled 77 active
+team_refresh_case "team refreshes when only the observed source differs" \
+  "source-only refresh full-PUTs the newly observed App ID" active 77 active
+team_refresh_case "team refreshes when only requested enforcement differs" \
+  "enforcement-only refresh full-PUTs requested enforcement" disabled 15368 active
 
 existing_profile_fixtures team active
 expect_rc 0 "exact canonical team match is idempotent" \
@@ -417,6 +428,16 @@ if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
   t_ok "solo persists intent without rewriting canonical team controls"
 else
   t_fail "solo persists intent without rewriting canonical team controls"
+fi
+
+existing_profile_fixtures team active 77
+expect_rc 0 "explicit solo ignores canonical team source drift" \
+  run_script -R acme/widget --profile solo --enforcement active
+if jq -e '.value == "solo"' "$GH_FIXTURES/variable-written.json" >/dev/null \
+   && ! grep -Eq -- '--method (PUT|POST).*rulesets' "$GH_CALLS"; then
+  t_ok "solo source drift persists solo intent with zero ruleset writes"
+else
+  t_fail "solo source drift persists solo intent with zero ruleset writes"
 fi
 
 existing_profile_fixtures team disabled


### PR DESCRIPTION
Closes #96

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5312359609

Authoritative implementation plan:
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5317789222
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5318457064

Production approval and release:
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5322011546
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5322017563

Production evidence and governance gates:
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5322082414
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/102#issuecomment-5322120541
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5322135172
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/pull/102#issuecomment-5322135348

Corrected tests checkpoint:
- https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/96#issuecomment-5319290260

## Summary

Adds the explicit `--reconcile` selector for safely reconciling exactly one canonical same-name ruleset to declared `solo|team` intent. Reconcile dry-runs perform validation using GET requests only; ordinary fresh-profile and legacy paths retain their prior behavior. Noncanonical, zero-match, duplicate, and failed-read paths stop before writes.

## Evidence

| Criterion | Evidence | Result |
|---|---|---|
| Focused recording wall | `bash .github/scripts/tests/run-tests.sh setup-ruleset` -> 88 cases, 0 failed | pass |
| Authenticated live reconcile dry-run | `gh auth status` passed; team payload jq predicate passed | pass |
| Live no-mutation proof | Observed methods: `GET /rulesets`, `GET /rulesets/20687261`, `GET /repos/...`, `GET /commits/main/check-runs`; POST/PUT/PATCH/DELETE: 0 | pass |
| Full scaffold wall | `bash .github/scripts/tests/run-tests.sh` -> all 23 guard test files passed | pass |
| Shell analysis | pinned ShellCheck v0.11.0; `git ls-files -z ".github/*.sh" \| xargs -0 shellcheck -S style` | pass |
| Action pins | `bash .github/scripts/check-action-pins.sh` | pass |
| Workflow permissions | `bash .github/scripts/check-workflow-permissions.sh` | pass |
| Escalation wording | `bash .github/scripts/check-escalation-wording.sh` | pass |
| Template sync | `bash .github/scripts/check-template-sync.sh` | pass |
| Markdown links | `bash .github/scripts/check-md-links.sh` | pass |
| Changelog references | `bash .github/scripts/check-changelog-refs.sh` | pass |
| Connectors | `bash .github/scripts/check-connectors.sh` | pass |
| Copilot surface | `bash .github/scripts/check-copilot-surface.sh` | pass |
| Hard line budget | production `84+/10-`, tests `290+/15-`, total 399/400 | pass |
| Fixed tests | test blob `f9a33237d1a353083a1a1d7b9494aafd55f5424e` unchanged | pass |
| Production artifact | production blob `c36e2cf098cab29851d5da2eb0f340b0dd5f1940`; production commit is exactly `9+/1-` | pass |
| Code-push exact-head CI | https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/32085919697 at `4bf91c694db62380c39eb1cfaded664de09b6872`; all five jobs passed | pass |
| Prior automatic body-sync CI | https://github.com/mochan-tk/agentic-dev-kit-for-copilot/actions/runs/32086130497 at the same exact head; all five jobs passed | pass |
| Final official Rubber Duck | exact head `4bf91c694db62380c39eb1cfaded664de09b6872`; parent `f13a5f5b0339fef4e47c6569e207c7045a246ebd`; conclusion PASS; findings none | pass |

## Final Rubber Duck

- Exact audited head: `4bf91c694db62380c39eb1cfaded664de09b6872`
- Parent: `f13a5f5b0339fef4e47c6569e207c7045a246ebd`
- Conclusion: **PASS**
- Findings: **none**
- Verified: exact production-only `+9/-1` scope, fixed tests, pre-`gh` profile guard, GET-only reconcile dry-run, fresh/legacy preservation, exact-one fail-closed guards, Bash 3.2 safety, no-downgrade and idempotency interactions.

## Deviations

None.

## Follow-ups

None for implementation. Ready-for-review is authorized, but merge remains blocked until the parent verifies the new ready/body-sync CI triggered by this metadata transition.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and is linked above.
- [x] Diff stays inside the issue's **File ownership** paths.
- [x] Every command in the issue's **Verification** section was run.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [x] Record-before-report comment posted on the Task issue by the supervisor.
- [x] All persistent artifacts in this PR are English-only.