### PR TITLE
Consume persisted governance intent in governance status

### DIFF
--- a/.github/scripts/governance-status.sh
+++ b/.github/scripts/governance-status.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # governance-status.sh — read-only default-branch governance sensor
 # (ADR-0004 decisions 1, 2, 4, 5). Compares effective branch rules, Actions
-# posture, CODEOWNERS tuning, and merge-queue applicability against an
-# explicitly declared solo or team intent (solo = the setup-ruleset.sh
-# minimum; stronger observed settings never make solo unhealthy). Aggregates
-# every active rule source including parent rulesets, qualifies
-# ruleset-derived controls with their bypass actors, and reports missing
-# evidence as UNKNOWN or UNCHECKABLE — never as safe. GET-only; nothing is
-# mutated and no profile is persisted.
+# posture, CODEOWNERS tuning, and merge-queue applicability against a solo
+# or team intent (solo = the setup-ruleset.sh minimum; stronger observed
+# settings never make solo unhealthy). When --profile is omitted, intent is
+# read from the persisted repository Actions variable
+# SCAFFOLD_GOVERNANCE_PROFILE (written by setup-ruleset.sh); only the exact
+# value solo or team is accepted, and explicit --profile is a one-shot
+# override that never reads that variable. Aggregates every active rule
+# source including parent rulesets, qualifies ruleset-derived controls with
+# their bypass actors, and reports missing evidence as UNKNOWN or
+# UNCHECKABLE — never as safe. GET-only; nothing is mutated and no profile
+# is persisted.
 #
 # Output: deterministic `key<TAB>state<TAB>detail` lines.
 # Exit: 0 healthy with complete evidence; 1 required control OFF;
@@ -43,8 +47,6 @@ trap 'rm -rf "$WORK"' EXIT
 TAB="$(printf '\t')"
 
 BASE=0 TEAM=0 UNMET=0 MISSING=0
-[ -z "$PROFILE" ] || BASE=1
-[ "$PROFILE" != team ] || TEAM=1
 
 # fetch <name> <path> [raw|page] — read-only GET; records ok|404|fail in
 # $WORK/<name>.rc. The only gh invocation shapes this sensor ever uses.
@@ -65,6 +67,24 @@ fetch() {
 }
 st() { cat "$WORK/$1.rc" 2>/dev/null || echo fail; }
 jqr() { jq -r "$1" "$WORK/$2.json"; }
+
+# Persisted governance intent: consulted only when no explicit --profile was
+# given, so an override never reads this endpoint. Only the exact value
+# solo or team is accepted — never trimmed, never case-folded — so a
+# missing variable, an Actions-disabled target, an API/authorization
+# failure, a malformed response, an empty value, a whitespace or case
+# variant, or any other value all leave PROFILE unset, which the existing
+# UNKNOWN/exit-3 path below already reports faithfully; no default is
+# guessed.
+if [ -z "$PROFILE" ]; then
+  fetch govvar "repos/$REPO/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE"
+  if [ "$(st govvar)" = ok ]; then
+    GV="$(jqr '.value // empty' govvar)"
+    case "$GV" in solo|team) PROFILE="$GV" ;; esac
+  fi
+fi
+[ -z "$PROFILE" ] || BASE=1
+[ "$PROFILE" != team ] || TEAM=1
 
 # emit <key> <state> <detail> <required-flag> — required OFF counts toward
 # exit 1; required UNKNOWN/UNCHECKABLE counts toward exit 3 (which outranks).

--- a/.github/scripts/tests/test-governance-status.sh
+++ b/.github/scripts/tests/test-governance-status.sh
@@ -47,6 +47,7 @@ case "$path" in
   repos/*/rulesets/*) f="rs-repo-${path##*/}.json" ;;
   orgs/*/rulesets/*) f="rs-org-${path##*/}.json" ;;
   orgs/*) f=org.json ;;
+  repos/*/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE) f=govvar.json ;;
   repos/*/actions/permissions/workflow) f=workflow.json ;;
   repos/*/commits/*/check-runs*) f=checkruns.json ;;
   repos/*/contents/.github/workflows/*) p="${path%%\?*}"; f="wff-${p##*/}" ;;
@@ -103,6 +104,7 @@ mk_marker() { printf '# log\n<!-- scaffold-version: repo=o/r sha=%s date=x -->\n
 mk_co() { printf '%s\n/.github/docs/agreements/ @owner\n' "$1" > "$GS_FIX/codeowners.raw"; }
 mk_wfdir() { local out="" sep="" n; for n in "$@"; do out="$out$sep{\"name\":\"$n\",\"type\":\"file\"}"; sep=","; done; printf '[%s]\n' "$out" > "$GS_FIX/wfdir.json"; }
 mk_wff() { printf '%s\n' "$2" > "$GS_FIX/wff-$1"; }
+mk_govvar() { printf '{"name":"SCAFFOLD_GOVERNANCE_PROFILE","value":"%s"}\n' "$1" > "$GS_FIX/govvar.json"; }
 
 RRB='[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"pull_request"}]'
 baseline() { # live-like template repository on the solo minimum
@@ -149,7 +151,74 @@ if [ "$first" = "$out" ]; then t_ok "output is deterministic across runs"; else 
 run -R o/r
 rce "omitted profile exits 3, never guessed" 3
 chk "omitted profile reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+if grep -q 'api repos/o/r/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE' "$GH_CALLS"; then t_ok "omitted profile is read from the persisted variable endpoint"; else t_fail "omitted profile is read from the persisted variable endpoint"; fi
 
+# Persisted governance intent (#101): with no --profile, the sensor reads
+# SCAFFOLD_GOVERNANCE_PROFILE and accepts only the exact value solo or team.
+baseline
+mk_govvar solo
+run -R o/r
+rce "persisted solo intent drives the same healthy report as explicit solo" 0
+chk "persisted solo profile is ACTIVE" "^governance\.profile${T}ACTIVE${T}solo$"
+
+team_green
+mk_govvar team
+run -R o/r
+rce "persisted team intent drives the same healthy report as explicit team" 0
+chk "persisted team profile is ACTIVE" "^governance\.profile${T}ACTIVE${T}team$"
+
+baseline
+mk_govvar team
+run -R o/r
+rce "persisted team intent still gates an unhardened repository" 1
+chk "persisted team gap: stale reviews OFF" "^pull_request\.dismiss_stale_reviews${T}OFF${T}false"
+
+baseline
+rm -f "$GS_FIX/govvar.json"
+run -R o/r
+rce "missing persisted variable exits 3, never guessed" 3
+chk "missing persisted variable reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+
+for bad in '' ' solo' 'solo ' 'Solo' 'TEAM' 'nonsense'; do
+  baseline
+  mk_govvar "$bad"
+  run -R o/r
+  rce "invalid persisted value '$bad' exits 3, never guessed" 3
+  chk "invalid persisted value '$bad' reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+done
+
+baseline
+printf '{"name":"SCAFFOLD_GOVERNANCE_PROFILE"}\n' > "$GS_FIX/govvar.json"
+run -R o/r
+rce "persisted payload without a value field exits 3" 3
+chk "absent value field reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+
+baseline
+printf 'not json\n' > "$GS_FIX/govvar.json"
+run -R o/r
+rce "malformed (non-JSON) persisted response exits 3" 3
+chk "malformed persisted response reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+
+baseline
+mk_govvar solo
+runf "actions/variables" -R o/r
+rce "persisted variable read failure (Actions-disabled or unauthorized) exits 3" 3
+chk "failed persisted read reported UNKNOWN" "^governance\.profile${T}UNKNOWN"
+
+baseline
+mk_govvar solo
+GH_CALLS_MARK="$(wc -l < "$GH_CALLS")"
+run -R o/r --profile team
+rce "explicit --profile overrides persisted intent" 1
+chk "explicit override drives team requirements, not the persisted solo value" "^pull_request\.dismiss_stale_reviews${T}OFF${T}false"
+NEWCALLS="$(tail -n "+$((GH_CALLS_MARK + 1))" "$GH_CALLS")"
+if printf '%s\n' "$NEWCALLS" | grep -q 'actions/variables/SCAFFOLD_GOVERNANCE_PROFILE'; then
+  t_fail "explicit --profile must not read the persisted variable endpoint"
+else
+  t_ok "explicit --profile never reads the persisted variable endpoint"
+fi
+
+baseline
 run -R o/r --profile team
 rce "solo baseline fails team intent" 1
 chk "team gap: stale reviews OFF" "^pull_request\.dismiss_stale_reviews${T}OFF${T}false"


### PR DESCRIPTION
Closes #101

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/101#issuecomment-5312592694

## Summary

`governance-status.sh` now sources solo/team intent from the persisted
repository Actions variable `SCAFFOLD_GOVERNANCE_PROFILE` by default (GET
`repos/{owner}/{repo}/actions/variables/SCAFFOLD_GOVERNANCE_PROFILE`),
accepting only the exact value `solo` or `team`. Explicit `--profile
solo|team` remains a one-shot override that short-circuits the persisted
lookup entirely (the endpoint is never read when an override is given).
A valid persisted value flows through the same BASE/TEAM derivation and
`emit` call as an equivalent explicit profile, so behavior is identical
regardless of source. Fixture tests were committed first and proven
expected-red before the implementation commit.

## Evidence

| Criterion | Evidence (command / link) | Result |
|---|---|---|
| Fixed fixtures committed first, expected-red before implementation | Tests-only commit 7b54028 stashed against pre-#101 `governance-status.sh`: `bash .github/scripts/tests/run-tests.sh governance-status` → 132/138 passing, 6 new persisted-intent cases failed (red), reproduced locally and recorded in the [implementation-release comment](https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/101#issuecomment-5312725868) | pass |
| GET for the variable when `--profile` omitted; exact `solo`/`team` only | `governance-status.sh` lines 79-87; unit tests "persisted solo intent…", "persisted team intent…" | pass |
| Valid persisted value → `ACTIVE`, same controls/order/exit as explicit | `run -R o/r` with `mk_govvar solo`/`team` vs `--profile solo`/`team`; `bash .github/scripts/tests/run-tests.sh governance-status` → 138/138 | pass |
| Missing/disabled/failed/malformed/empty/whitespace/case/other → `UNKNOWN`, exit 3 | Unit tests: missing variable, 6-value invalid loop (`''`, `' solo'`, `'solo '`, `'Solo'`, `'TEAM'`, `'nonsense'`), missing `value` field, non-JSON payload, simulated `actions/variables` API failure — all rc=3, `governance.profile UNKNOWN` | pass |
| Explicit `--profile` takes precedence, never reads the endpoint, preserves #92 | Unit test "explicit --profile overrides persisted intent" (scoped `GH_CALLS` diff proves no call to the variables endpoint); full `--profile` test matrix (solo/team/checks/usage errors) unchanged and passing | pass |
| GET-only; fails on any mutating call | `bash .github/scripts/tests/run-tests.sh governance-status` → "sensor performed GET-only gh calls", "every gh invocation is a plain gh api read", "shim wall refuses mutating invocations" all pass | pass |
| Existing aggregation/bypass/source-binding/Actions/CODEOWNERS/merge-queue/UNKNOWN precedence/Bash 3.2/output order unchanged outside profile-source selection | Full pre-existing 132-case suite unchanged and passing; live explicit `--profile solo` probe against `mochan-tk/agentic-dev-kit-for-copilot` | pass |
| PR stays within ~400 changed lines across the two owned paths | `git diff --numstat origin/main...HEAD -- .github/scripts/governance-status.sh .github/scripts/tests/test-governance-status.sh` → 107 | pass |
| `gh auth status` | Logged in, GH_TOKEN active | pass |
| `bash .github/scripts/tests/run-tests.sh governance-status` | 138 case(s), 0 failed | pass |
| Live explicit probe (`--profile solo`) | rc=0, `governance.profile\tACTIVE\tsolo` | pass |
| Live persisted probe (no `--profile`) | rc=3, `governance.profile\tUNKNOWN\tno profile declared; pass --profile solo\|team` (this repository has not opted into `SCAFFOLD_GOVERNANCE_PROFILE`, so UNKNOWN/exit 3 is the correct, non-guessed result) | pass |
| `bash .github/scripts/tests/run-tests.sh` (full wall) | 23 guard test file(s) passed | pass |
| `git ls-files -z ".github/*.sh" \| xargs -0 shellcheck -S style` | clean, no output | pass |
| `check-action-pins.sh` | All action references are SHA-pinned | pass |
| `check-workflow-permissions.sh` | 16 job(s) checked, OK | pass |
| `check-escalation-wording.sh` | OK, 20 surfaces scanned | pass |
| `check-template-sync.sh` | OK, issue forms and body templates in sync | pass |
| `check-md-links.sh` | OK, 44 references resolve | pass |
| `check-changelog-refs.sh` | OK, 47 references within #200 | pass |
| `check-connectors.sh` | OK, 2 connector definitions conform | pass |
| `check-copilot-surface.sh` | OK, skills/agents/prompts/instructions validated | pass |

## Deviations

None. Implementation matches the plan of record exactly: only the two
owned files were touched, `--profile` remains a one-shot override with no
persisted read, and every other sensor behavior (aggregation, bypass
qualification, source binding, exit precedence, Bash 3.2 compatibility,
line-oriented output) is unchanged.

## Follow-ups

None.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and is
      linked above.
- [x] Diff stays inside the issue's **File ownership** paths (single-writer
      rule, or a declared agreements wording rider).
- [x] Every command in the issue's **Verification** section was run; output captured above.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [ ] Record-before-report comment posted on the Task issue. (Per the
      worker protocol — session-orchestration skill — a worker never posts
      the ritual/outcome comments on the Task issue; the supervisor
      independently verifies this PR and posts the outcome comment.)
- [x] All persistent artifacts in this PR are English-only.
