### PR TITLE
Rename Program session to Project session

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-description: Conductor session, at either layer — program (starts each Epic's session as its phase comes up, watches across phases, replans the outline) or Epic parent (computes the actionable frontier, dispatches Task issues to child sessions or the cloud agent, steers running work, independently verifies reports, keeps GitHub Issues/Projects synchronized with reality). Never writes application code.
+description: Conductor session, at either layer — Project session (starts each Epic's session as its phase comes up, watches across phases, replans the outline) or Epic parent (computes the actionable frontier, dispatches Task issues to child sessions or the cloud agent, steers running work, independently verifies reports, keeps GitHub Issues/Projects synchronized with reality). Never writes application code.
 # Tool aliases per GitHub Docs "Custom agents configuration"
 # (docs.github.com/en/copilot/reference/custom-agents-configuration):
 # no `edit` — the orchestrator conducts and verifies, it never edits files;
@@ -33,10 +33,10 @@ tools: ["read", "search", "execute", "agent", "github/*",
 ---
 
 You are the orchestrator. You conduct; you do not implement. The role runs at
-two layers, and the session you are in decides which: as a **program
+two layers, and the session you are in decides which: as a **Project
 session** you conduct the whole Epic set — starting each Epic's session when
 its phase comes up, watching across phases, replanning when the outline
-diverges (`session-orchestration` §Program session protocol). As an **Epic's
+diverges (`session-orchestration` §Project session protocol). As an **Epic's
 parent session** you run the delivery loop below for that one Epic. It is not
 the role for supervising a single Task: that runs on the default agent with
 the session-orchestration skill (`task-routing`). Either

--- a/.github/docs/context/session-naming/2026-08-18-owner-decision.md
+++ b/.github/docs/context/session-naming/2026-08-18-owner-decision.md
@@ -1,0 +1,40 @@
+---
+source: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/113
+retrieved: 2026-08-18
+method: ai-summary
+collector: Copilot app worker session 6f6d8a1e-d72a-45b0-aaea-d88a5672e1fc
+sensitivity: public
+status: raw
+---
+
+# Owner naming decision
+
+The repository owner supplied a translated and condensed summary of a
+2026-08-18 consultation, including an external ChatGPT Pro analysis originally
+provided in Japanese. The requested direction is to call the top-level Copilot
+app session the **Project session**.
+
+The Project session supervises the complete Epic set for one repository-level
+initiative. It starts each Epic orchestrator session when that phase becomes
+actionable, watches progress across phases, and replans the outline when
+reality diverges. The name does not refer to, rename, or change a GitHub
+Projects board.
+
+The four-layer hierarchy remains:
+
+```text
+Project session
+ └─ Epic orchestrator session
+    └─ Task supervisor session
+       └─ PR worker session
+```
+
+This is a terminology migration only. Responsibilities, parent/child behavior,
+session lifetime and teardown, tools, the issue graph, branch naming, labels,
+CI, Task rituals, and GitHub Projects behavior remain unchanged. Existing live
+or archived sessions named `Program` remain valid; newly created top-level
+sessions are named exactly `Project`. Historical records are not rewritten.
+
+Because this note is an AI summary of translated and condensed material rather
+than the original consultation, re-verify it against the linked Task issue
+before promoting it to a reviewed agreement.

--- a/.github/docs/context/session-naming/INDEX.md
+++ b/.github/docs/context/session-naming/INDEX.md
@@ -1,0 +1,29 @@
+---
+source: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/113
+retrieved: 2026-08-18
+method: ai-summary
+collector: Copilot app worker session 6f6d8a1e-d72a-45b0-aaea-d88a5672e1fc
+sensitivity: public
+status: raw
+---
+
+# Session naming context
+
+## Open questions
+
+None were recorded in the supplied decision. The source material is translated
+and condensed, so it must be re-verified before promotion to an agreement.
+
+## Sources
+
+- `2026-08-18-owner-decision.md` — summarizes the repository owner's
+  2026-08-18 naming decision, its scope, preserved behavior, and migration
+  boundary.
+
+## Final requested direction
+
+Use **Project session** for the top-level Copilot app session and name newly
+created instances exactly `Project`. Preserve the hierarchy Project session →
+Epic orchestrator session → Task supervisor session → PR worker session.
+Treat the name as unrelated to a GitHub Projects board, retain existing
+sessions named `Program`, and do not change behavior or historical records.

--- a/.github/prompts/onboard-project.prompt.md
+++ b/.github/prompts/onboard-project.prompt.md
@@ -48,13 +48,13 @@ Optional context from me: ${input:notes}
    everything left undone in P0–P5 to the first phase Epic's body as a
    `## Deferred from onboarding` checklist (to the PR description when the
    Epics were skipped), and end the PR description with a `## Next steps`
-   section (merge this PR → review the Epics → hand off to the `Program`
+   section (merge this PR → review the Epics → hand off to the `Project`
    session). You are
    not done at push: the PR must exist (if its creation is blocked, tell me
    and print the exact `gh pr create` command), and the chat message where
    you hand me the PR link must end with the numbered handoff — 1. merge
    the evidence PR, 2. review the draft Epics (link them), 3. tell the
-   `Program` session to start once the PR is merged. Create that session as
+   `Project` session to start once the PR is merged. Create that session as
    your last act, handing it the Epic numbers and which phase is first;
    never decompose here yourself. Queued or failing checks
    don't waive the handoff: report problems above it, never instead of it.

--- a/.github/scripts/check-copilot-surface.sh
+++ b/.github/scripts/check-copilot-surface.sh
@@ -231,6 +231,6 @@ PY
 
 # The frontmatter above is validated as YAML; whether the tools it grants
 # match the protocol the agent is told to run is a separate question, and
-# one nothing asked until an adopter's Program session could not create a
+# one nothing asked until an adopter's Project session could not create a
 # session (#47). Delegated so the check stays testable on its own inputs.
 bash "$ROOT/.github/scripts/check-agent-tools.sh"

--- a/.github/skills/project-onboarding/SKILL.md
+++ b/.github/skills/project-onboarding/SKILL.md
@@ -255,14 +255,14 @@ PR description instead.
 Chat is not a carrier: a deferred item that exists only in the final
 message evaporates with the session.
 
-**Start the program session** as onboarding's last act, once the evidence
-PR exists and the Epics are drafted: create a session named `Program`
-(`session-orchestration` §Program session protocol) and hand it the Epic
+**Start the Project session** as onboarding's last act, once the evidence
+PR exists and the Epics are drafted: create a session named `Project`
+(`session-orchestration` §Project session protocol) and hand it the Epic
 numbers and which phase is first. It waits for the evidence PR to merge
 before starting the first Epic's session — a phase run against a half-tuned
 repository verifies nothing. Onboarding does not decompose, and does not
-become the program session itself: its context is spent, and conducting is
-a different job. When the Epics were skipped, create no program session and
+become the Project session itself: its context is spent, and conducting is
+a different job. When the Epics were skipped, create no Project session and
 say so — there is nothing to conduct until an Epic exists.
 
 P6 is not complete when the branch is pushed — it is complete when the
@@ -277,7 +277,7 @@ report them *above* the block, never instead of it.
 1. Review and merge the evidence PR (the license merge).
 2. Review and edit the P2-close draft Epics — link them here, first phase
    first (or say they were skipped and point at the Epic form).
-3. Once the evidence PR is merged, tell the `Program` session to start —
+3. Once the evidence PR is merged, tell the `Project` session to start —
    it decomposes the first phase's Epic on your approval, one phase at a
    time, and starts each later Epic's session as its turn comes.
 

--- a/.github/skills/session-orchestration/SKILL.md
+++ b/.github/skills/session-orchestration/SKILL.md
@@ -15,7 +15,7 @@ record on GitHub while using sessions for speed.
 
 | Plan object | Session object | Workspace object |
 |---|---|---|
-| The Epic set (whole project) | One program session (conductor of conductors) | — |
+| The Epic set (whole project) | One Project session (conductor of conductors) | — |
 | Epic issue | Parent (orchestrator) session | — |
 | Task issue | One supervisor session (ritual only, no code edits) | — |
 | Pull request | One active worker session | One worktree + branch `task/<n>-<slug>` (or accepted tool-prefixed variant) |
@@ -48,7 +48,7 @@ it. Sub-agents remain fine for what they are — bounded read-only research
 inside one turn.
 
 **Role boundaries.** A session's role is fixed when it is created; it is not
-something a session reasons its way out of mid-run. A conductor (program or
+something a session reasons its way out of mid-run. A conductor (Project or
 Epic) that finds itself about to edit application files, check out a Task
 branch, or commit has met the boundary, whatever the justification: file or
 locate the Task issue, dispatch it, and verify — or escalate (§6). "It is
@@ -251,9 +251,9 @@ You are the WORKER session for Task issue #<n> in <owner>/<repo>.
 - Do NOT post comments on the issue; report to your supervisor session and stop.
 ```
 
-## Program session protocol
+## Project session protocol
 
-One program session per project, created by onboarding as its closing move
+One Project session per project, created by onboarding as its closing move
 (`project-onboarding` P6) once the phase Epics exist, and kept for the life
 of the plan. It conducts conductors: it never decomposes, dispatches Tasks,
 or edits code itself. Its first move waits for the onboarding evidence PR to
@@ -264,22 +264,22 @@ merge — a phase started against a half-tuned repository verifies nothing.
    Epic number and nothing else; the Epic is the brief. Name it `Epic #<n>`
    (session naming: §Copilot app session tree).
 2. **Epic sessions are siblings, not descendants.** An Epic session that
-   sees the next phase becoming actionable reports that to the program
+   sees the next phase becoming actionable reports that to the Project
    session rather than starting a peer itself: sessions spawning their
    successors nest one level deeper per phase, and after a few phases the
    tree is unreadable. Epics are siblings in the issue graph; their sessions
    mirror that.
 3. **Watch across Epics, not within one.** Phase-spanning trouble is the
-   program session's business: an Epic whose blockers never clear, a
+   Project session's business: an Epic whose blockers never clear, a
    dependency that turns out to be backwards, repeated escalations of the
    same shape. Within an Epic, its own session decides.
 4. **Replan across phases** (`plan-management` skill) when reality diverges
    from the outline — reordering phases, splitting one, dropping another.
    Record the rationale on the affected Epic, not in session memory.
-5. **Ending.** Program sessions die like any other: before one ends, the
+5. **Ending.** Project sessions die like any other: before one ends, the
    state of play must be legible from GitHub alone — each Epic's status
    visible from its issue, its comments, and the board. Whoever restarts a
-   program session reads the graph, not the transcript.
+   Project session reads the graph, not the transcript.
 
 ## Parent session protocol
 
@@ -327,14 +327,14 @@ merge — a phase started against a half-tuned repository verifies nothing.
 6. Route `needs-replan` outcomes to the planner procedure
    (`plan-management` §Replanning) and post the rationale on the Epic.
 7. When the Epic's phase is done — its Tasks closed, their PRs merged, the
-   Epic's own state line current — tell the program session so the next
+   Epic's own state line current — tell the Project session so the next
    phase gets a session, then stop. Do not start that session yourself and
-   do not carry on as it: the program session keeps Epic sessions siblings
-   (see Program session protocol), and a session that continues into the
+   do not carry on as it: the Project session keeps Epic sessions siblings
+   (see Project session protocol), and a session that continues into the
    next phase makes the tree a single thread again. Stay open until the
    Epic closes — rework and late questions come back here. If
-   no program session is running, say so in the Epic's closing comment and
-   name the next Epic, so a human or a fresh program session can pick it up.
+   no Project session is running, say so in the Epic's closing comment and
+   name the next Epic, so a human or a fresh Project session can pick it up.
 
 ## Copilot app session tree
 
@@ -352,7 +352,7 @@ tree. Two structural facts shape it:
   resuming from the ledger.
 
 **Name sessions after what they work on**, so a sidebar of open sessions can
-be read without opening any of them: `Program`, `Epic #1`, `Task #6
+be read without opening any of them: `Project`, `Epic #1`, `Task #6
 supervisor`, `PR #12 worker`. Keep the `#` — a bare number could be anything,
 and a worker's PR number is not its Task's. Issue titles stay out: names are
 display strings in a narrow column, where short and uniform beats descriptive
@@ -380,7 +380,7 @@ acknowledges → only then does the requester archive the supervisor.
 **Conducting sessions are not torn down with them.** Teardown covers the
 executing layers only: workers and Task supervisors, which carry the
 heaviest context and whose record already lives on GitHub. An **Epic
-session lives until its Epic closes**; the **program session lives as long
+session lives until its Epic closes**; the **Project session lives as long
 as the plan**. Keeping them is what makes the tree readable — `Epic #1` and
 `Epic #2` side by side — and guarantees a live session owns starting the
 next phase. Archiving them instead leaves the plan with no conductor, and

--- a/.github/skills/task-routing/SKILL.md
+++ b/.github/skills/task-routing/SKILL.md
@@ -20,7 +20,7 @@ small-task exemption, the label routes that single session.
 **A Task supervisor runs on the default agent** with
 `.github/skills/session-orchestration/SKILL.md` as its manual — the ritual is
 fully described there, so no separate role definition exists. Do not pick
-`orchestrator` for it: that role conducts the program and Epic layers, and
+`orchestrator` for it: that role conducts the Project and Epic layers, and
 its loop is written for a different job.
 
 ## Routing inputs

--- a/README.md
+++ b/README.md
@@ -213,10 +213,14 @@ degrades every request a little.
 
 **Prerequisites:** `gh` (authenticated — check with `gh auth status`; the
 setup scripts refuse to run without it), `jq`, and the **GitHub Copilot
-app** — the lifecycle runs on its session hierarchy (a program session
+app** — the lifecycle runs on its session hierarchy (a Project session
 starts each Epic's session, which supervises its Tasks), which no other
 surface provides. Copilot CLI and IDE chat execute individual tasks
 alongside it; they are not substitutes for the app.
+
+The **Project session** is the top-level Copilot app session that supervises
+the complete Epic set for one repository-level initiative. It is unrelated to
+a GitHub Projects board.
 
 **On Windows**, also install [Git for Windows](https://gitforwindows.org) —
 the app already requires Git, and its `bash.exe` is what runs these scripts.

--- a/SCAFFOLD-CHANGELOG.md
+++ b/SCAFFOLD-CHANGELOG.md
@@ -45,6 +45,11 @@ inherit what this one learned.
 
 ### Unreleased
 
+- The top-level Copilot app role is now called the `Project session`, and new
+  sessions use the name `Project`. Existing sessions named `Program` remain
+  valid; no branch, label, issue, PR, Task-ritual, or runtime session migration
+  is required (#113).
+
 - Operator-facing governance documentation now integrates ADR-0004's sensor and
   actuator boundary in one place: the README maps `ownership-overlap.sh`,
   `governance-drift.sh`, `governance-status.sh`, and `setup-ruleset.sh`


### PR DESCRIPTION
Closes #113

Plan: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/113#issuecomment-5329395254

Outcome: https://github.com/mochan-tk/agentic-dev-kit-for-copilot/issues/113#issuecomment-5329617625

## Summary

Renames the active top-level Copilot app role from `Program session` to `Project session` across the owned orchestration, onboarding, routing, validation-comment, and README surfaces. Records the translated and condensed 2026-08-18 owner decision with `ai-summary` provenance, names newly created top-level sessions exactly `Project`, and preserves all behavior and historical changelog entries.

## Evidence

| Criterion | Evidence (command / link) | Result |
|---|---|---|
| Collect the naming decision with complete provenance and indexed source, open questions, and final direction | `.github/docs/context/session-naming/2026-08-18-owner-decision.md` and `INDEX.md`; `bash .github/scripts/check-copilot-surface.sh` | pass |
| Use `Project session` consistently throughout session orchestration | `.github/skills/session-orchestration/SKILL.md`; obsolete-term verification grep emitted nothing | pass |
| Preserve the four-layer hierarchy and parent/child behavior | Context decision tree and session-orchestration mapping/protocol diff; `bash .github/scripts/tests/run-tests.sh` -> all 23 guard files passed | pass |
| Update orchestrator, routing, onboarding skill, and onboarding prompt consistently | Owned-file diff; `bash .github/scripts/check-agent-tools.sh` -> 6 protocol rows reconciled against 12 granted tools | pass |
| Create new onboarding sessions named exactly `Project` with Epic numbers and first phase | `.github/skills/project-onboarding/SKILL.md` P6 and `.github/prompts/onboard-project.prompt.md` | pass |
| Update README prerequisites and define the term as unrelated to GitHub Projects | `README.md` Getting started diff; `bash .github/scripts/check-md-links.sh` -> 48 references resolved | pass |
| Change only the relevant terminology comment in `check-copilot-surface.sh` | `git diff origin/main...HEAD -- .github/scripts/check-copilot-surface.sh` shows one comment-only replacement; surface check passed | pass |
| Add exactly one Unreleased migration note and preserve historical entries | `git diff --unified=0 origin/main...HEAD -- SCAFFOLD-CHANGELOG.md` shows one five-line Unreleased addition; `bash .github/scripts/check-changelog-refs.sh` passed | pass |
| Leave no obsolete active top-level name outside raw context | `test -z "$(git grep -n -i -E 'program session|program layer|program and Epic|named \`Program\`|\`Program\` session' -- README.md .github/agents .github/prompts .github/skills .github/scripts/check-copilot-surface.sh)"` | pass |
| Preserve behavior, allowlists, issue graph, branches, labels, CI, Task ritual, and GitHub Projects semantics | Full guard suite, surface check, agent-tool check, and Rubber Duck consistency pass all reported no substantive findings | pass |

## Deviations

Execution-only: PR #114 was automatically closed by GitHub when the worker's remote branch was restored to the immutable dispatch-record name `mochan-tk-effective-pancake` after the mandatory branch-rename step caused the initial Task-ritual mismatch. This replacement PR uses the restored dispatched head; implementation commit `9290b18` and its contents are unchanged.

## Follow-ups

None.

## Checklist

- [x] Plan was posted as a Task-issue comment before implementation and is linked above.
- [x] Diff stays inside the issue's **File ownership** paths (single-writer rule, or a declared agreements wording rider).
- [x] Every command in the issue's **Verification** section was run; output captured above.
- [x] No test, lint rule, or CI check was deleted, skipped, or weakened.
- [x] Record-before-report comment posted on the Task issue and linked above.
- [x] All persistent artifacts in this PR are English-only.